### PR TITLE
Validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Build output
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Build output
 build/
+
+__pycache__

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,7 @@ latexdiff: latex
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+check:
+	python3 -m fit_validate.validate_test
+	pylint fit_validate/*.py

--- a/README.md
+++ b/README.md
@@ -83,6 +83,28 @@ Make commands:
 
 Output goes in ./build subdirectory.
 
+## FIT Validation ##
+
+A simple validator is included to check FIT-format files. This is
+work-in-progress, in that it does not include the full schema.
+
+To use it:
+
+>```
+>pip install dtoc
+>python3 -m fit_validate.validate <filename>
+>```
+
+where <filename> is the FIT file to validate.
+
+The files are as follows:
+
+* validate.py        - FIT validator
+* fdt_validate.py    - Generic devicetree validator
+* schema.py          - FIT schema
+* elements.py        - Generic elements used by the schema
+* validate_test.py   - tests for the FIT validator
+
 ## License ##
 This project is licensed under the Apache V2 license. More information can be found 
 in the LICENSE and NOTICE file or online at:

--- a/fit_validate/__init__.py
+++ b/fit_validate/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0+
+"""All of the modules"""
+
+__all__ = [
+    'elements', 'fdt_validate', 'validate', 'validate_test',
+    'schema',
+]

--- a/fit_validate/elements.py
+++ b/fit_validate/elements.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright 2023 Google LLC
+# Written by Simon Glass <sjg@chromium.org>
+
+"""Schema elements
+
+This module provides schema elements that can be used to build up a schema for
+validation of a devicetree.
+"""
+
+import re
+
+# pylint: disable=E0401
+from dtoc.fdt import Type
+from dtoc import fdt_util
+
+def get_node_path(prop):
+    """Get the path of a property's node
+
+    Args:
+        prop (fdt.Prop): Property to look up
+
+    Returns:
+        str: Full path to the node containing this property
+    """
+    # pylint: disable=W0212
+    return prop._node.path
+
+
+def check_phandle_target(target, target_path_match):
+    """Check that the target of a phandle matches a pattern
+
+    Args:
+        target (str): Target node path
+        target_path_match (str): Match string. This is the full path to the
+            node that the target must point to. Some 'wildcard' nodes are
+            supported in the path:
+                ANY - matches any node
+
+    Returns:
+        True if the target matches, False if not
+    """
+    parts = target_path_match.split('/')
+    target_parts = target.path.split('/')
+    valid = len(parts) == len(target_parts)
+    if valid:
+        for i, part in enumerate(parts):
+            if part == 'ANY':
+                continue
+            if part != target_parts[i]:
+                valid = False
+    return valid
+
+
+# pylint: disable=R0903
+class SchemaElement():
+    """A schema element, either a property or a subnode
+
+    Args:
+        name: Name of schema eleent
+        prop_type: String describing this property type
+        required: True if this element is mandatory, False if optional
+        conditional_props: Properties which control whether this element is
+            present. Dict:
+                key: name of controlling property
+                value: True if the property must be present, False if it must be
+                    absent
+    """
+    def __init__(self, name, prop_type, required=False, conditional_props=None):
+        self.name = name
+        self.prop_type = prop_type
+        self.required = required
+        self.conditional_props = conditional_props
+        self.parent = None
+
+    def validate(self, val, prop_or_node):
+        """Validate the schema element against the given property.
+
+        This method is overridden by subclasses. It should call val.fail() if
+        there is a problem during validation.
+
+        Args:
+            val (FdtValidator): Validator object
+            prop_or_node (fdt.Prop or fdt.Node): Node or property to validate
+        """
+
+
+class PropDesc(SchemaElement):
+    """A generic property schema element (base class for properties)"""
+    def validate(self, val, prop_or_node):
+        self.validate_prop(val, prop_or_node)
+
+    def validate_prop(self, val, prop):
+        """Validate a property
+
+        Args:
+            val (FdtValidator): Validator information
+            prop (fdt.Prop): Property to validate
+        """
+
+
+class PropString(PropDesc):
+    """A string-property
+
+    Args:
+        str_pattern: Regex to use to validate the string
+    """
+    def __init__(self, name, required=False, str_pattern='',
+                             conditional_props=None):
+        super().__init__(name, 'string', required, conditional_props)
+        self.str_pattern = str_pattern
+
+    def validate_prop(self, val, prop):
+        """Check the string with a regex"""
+        if not self.str_pattern:
+            return
+        pattern = '^' + self.str_pattern + '$'
+        val_m = re.match(pattern, prop.value)
+        if not val_m:
+            val.fail(
+                get_node_path(prop),
+                f"'{prop.name}' value '{prop.value}' does not match pattern '{pattern}'")
+
+
+class PropInt(PropDesc):
+    """Single-cell (32-bit) integer"""
+    def __init__(self, name, required=False, conditional_props=None):
+        super().__init__(name, 'int', required, conditional_props)
+
+    def validate_prop(self, val, prop):
+        """Check the timestamp"""
+        if prop.type != Type.INT:
+            val.fail(
+                get_node_path(prop),
+                f"'{prop.name}' value '{prop.value}' must be a u32")
+
+
+class PropTimestamp(PropInt):
+    """A timestamp in u32 format"""
+
+
+class PropAddressCells(PropDesc):
+    """An #address-cells property"""
+    def __init__(self, required=False, conditional_props=None):
+        super().__init__('#address-cells', 'address-cells', required,
+                         conditional_props)
+
+    def validate_prop(self, val, prop):
+        """Check the timestamp"""
+        if prop.type != Type.INT:
+            val.fail(
+                get_node_path(prop),
+                f"'{prop.name}' value '{prop.value}' must be a u32")
+        val = fdt_util.fdt32_to_cpu(prop.value)
+        if val not in [1, 2]:
+            val.fail(get_node_path(prop),
+                     f"'{prop.name}' value '{val}' must be 1 or 2")
+
+
+class PropBool(PropDesc):
+    """Boolean property"""
+    def __init__(self, name, required=False, conditional_props=None):
+        super().__init__(name, 'bool', required, conditional_props)
+
+
+class PropStringList(PropDesc):
+    """A string-list property schema element
+
+    Note that the list may be empty in which case no validation is performed.
+
+    Args:
+        str_pattern: Regex to use to validate the string
+    """
+    def __init__(self, name, required=False, str_pattern='',
+                             conditional_props=None):
+        super().__init__(name, 'stringlist', required, conditional_props)
+        self.str_pattern = str_pattern
+
+    def validate_prop(self, val, prop):
+        """Check each item of the list with a regex"""
+        if not self.str_pattern:
+            return
+        pattern = '^' + self.str_pattern + '$'
+        for item in prop.value:
+            m_str = re.match(pattern, item)
+            if not m_str:
+                val.fail(
+                    prop.node.path,
+                    f"'{prop.name}' value '{item}' does not match pattern '{pattern}'")
+
+
+class PropPhandleTarget(PropDesc):
+    """A phandle-target property schema element
+
+    A phandle target can be pointed to by another node using a phandle property.
+    """
+    def __init__(self, required=False, conditional_props=None):
+        super().__init__('phandle', 'phandle-target', required,
+                         conditional_props)
+
+
+class PropPhandle(PropDesc):
+    """A phandle property schema element
+
+    Phandle properties point to other nodes, and allow linking from one node to
+    another.
+
+    Properties:
+        target_path_match: String to use to validate the target of this phandle.
+                It is the full path to the node that it must point to. See
+                check_phandle_target for details.
+    """
+    def __init__(self, name, target_path_match, required=False,
+                             conditional_props=None):
+        super().__init__(name, 'phandle', required, conditional_props)
+        self.target_path_match = target_path_match
+
+    def validate_prop(self, val, prop):
+        """Check that this phandle points to the correct place"""
+        phandle = prop.GetPhandle()
+        target = prop.fdt.LookupPhandle(phandle)
+        if not check_phandle_target(target, self.target_path_match):
+            val.fail(
+                prop.node.path,
+                f"Phandle '{prop.name}' targets node '{target.path}' which does not "
+                f"match pattern '{self.target_path_match}'")
+
+
+class PropCustom(PropDesc):
+    """A custom property with its own validator
+
+    Properties:
+        validator: Function to call to validate this property
+    """
+    def __init__(self, name, validator, required=False, conditional_props=None):
+        super().__init__(name, 'custom', required, conditional_props)
+        self.validator = validator
+
+    def validate_prop(self, val, prop):
+        """Validator for this property
+
+        This should be a static method in FdtValidator.
+
+        Args:
+            val (FdtValidator): Validator object
+            prop (fdt.Prop): Prop object of the property
+        """
+        self.validator(val, prop)
+
+
+class PropAny(PropDesc):
+    """A placeholder for any property name
+
+    Properties:
+        validator: Function to call to validate this property
+    """
+    def __init__(self, validator=None):
+        super().__init__('ANY', 'any')
+        self.validator = validator
+
+    def validate_prop(self, val, prop):
+        """Validator for this property
+
+        This should be a static method in FdtValidator.
+
+        Args:
+            val (FdtValidator): Validator object
+            prop (fdt.Prop): Prop object of the property
+        """
+        if self.validator:
+            self.validator(val, prop)
+
+
+class PropOneOf(PropDesc):
+    """Allows selecting one of a variety of options
+
+    Properties:
+        validator: Function to call to validate this property
+    """
+    def __init__(self, name, required=False, options=None,
+                 conditional_props=None):
+        super().__init__(name, 'oneof', required, conditional_props)
+        self.options = options or []
+
+    def validate_prop(self, val, prop):
+        """Validator for this property
+
+        This should be a static method in FdtValidator.
+
+        Args:
+            val (FdtValidator): Validator object
+            prop (fdt.Prop): Prop object of the property
+        """
+
+
+class NodeDesc(SchemaElement):
+    """A generic node schema element (base class for nodes)"""
+    def __init__(self, name, required=False, elements=None,
+                             conditional_props=None):
+        super().__init__(name, 'node', required, conditional_props)
+        self.elements = elements
+        for element in elements:
+            element.parent = self
+
+    def get_nodes(self):
+        """Get a list of schema elements which are nodes
+
+        Returns:
+            List of objects, each of which has NodeDesc as a base class
+        """
+        return [n for n in self.elements if isinstance(n, NodeDesc)]
+
+    def validate(self, val, prop_or_node):
+        self.validate_node(val, prop_or_node)
+
+    def validate_node(self, val, node):
+        """Validate a node
+
+        Args:
+            val (FdtValidator): Validator information
+            node (fdt.Node): Node to validate
+        """
+
+
+class NodeModel(NodeDesc):
+    """A generic node schema element (base class for nodes)"""
+    def __init__(self, elements):
+        super().__init__('MODEL', elements=elements)
+
+
+class NodeSubmodel(NodeDesc):
+    """A generic node schema element (base class for nodes)"""
+    def __init__(self, elements):
+        super().__init__('SUBMODEL', elements=elements)
+
+
+class NodeAny(NodeDesc):
+    """A generic node schema element (base class for nodes)"""
+    def __init__(self, name_pattern, elements):
+        super().__init__('ANY', elements=elements)
+        self.name_pattern = name_pattern
+
+    def validate_node(self, val, node):
+        """Check the name with a regex"""
+        if not self.name_pattern:
+            return
+        pattern = '^' + self.name_pattern + '$'
+        m_name = re.match(pattern, node.name)
+        if not m_name:
+            val.fail(
+                node.path,
+                f"Node name '{node.name}' does not match pattern '{pattern}'")
+
+    def add_element(self, elem):
+        """Add a new element to a NodeAny
+
+        Args:
+        """
+        self.elements.append(elem)
+        elem.parent = elem
+
+
+class NodeImage(NodeAny):
+    """A FIT image node"""
+    def __init__(self, name_pattern, elements):
+        super().__init__(name_pattern=name_pattern, elements=elements)
+
+
+class NodeConfig(NodeAny):
+    """A FIT config node"""
+    def __init__(self, name_pattern, elements):
+        super().__init__(name_pattern=name_pattern, elements=elements)

--- a/fit_validate/elements.py
+++ b/fit_validate/elements.py
@@ -225,8 +225,9 @@ class PropStringList(PropDesc):
         str_pattern: Regex to use to validate the string
     """
     def __init__(self, name, required=False, str_pattern='',
-                             conditional_props=None):
-        super().__init__(name, 'stringlist', required, conditional_props)
+                             conditional_props=None, required_when=None):
+        super().__init__(name, 'stringlist', required, conditional_props,
+                         required_when)
         self.str_pattern = str_pattern
 
     def validate_prop(self, val, prop):

--- a/fit_validate/elements.py
+++ b/fit_validate/elements.py
@@ -201,6 +201,69 @@ class PropStringList(PropDesc):
                     f"'{prop.name}' value '{item}' does not match pattern '{pattern}'")
 
 
+class PropNodeRef(PropString):
+    """A string property whose value names another node by unit name
+
+    The target node lives at ``<target_parent_path>/<value>``. Used for
+    image and configuration references, where one node points at another
+    by name rather than via a phandle.
+
+    Properties:
+        target_parent_path: Path of the parent under which the target lives
+            (e.g. '/images')
+        no_chain: True if the target node must not itself have a property of
+            this same name (used for image-data, where chains are forbidden)
+    """
+    def __init__(self, name, target_parent_path, required=False,
+                 conditional_props=None, no_chain=False):
+        super().__init__(name, required, conditional_props=conditional_props)
+        self.target_parent_path = target_parent_path
+        self.no_chain = no_chain
+
+    def validate_prop(self, val, prop):
+        super().validate_prop(val, prop)
+        if not isinstance(prop.value, str):
+            return
+        target_path = self.target_parent_path + '/' + prop.value
+        target = val.get_node(target_path)
+        if target is None:
+            val.fail(get_node_path(prop),
+                     f"'{prop.name}' references missing node '{target_path}'")
+            return
+        if self.no_chain and self.name in target.props:
+            val.fail(get_node_path(prop),
+                     f"'{prop.name}' target '{prop.value}' itself has a "
+                     f"'{self.name}' property; chains are not permitted")
+
+
+class PropImageRef(PropNodeRef):
+    """A property whose value names a node under /images"""
+    def __init__(self, name, required=False, conditional_props=None,
+                 no_chain=False):
+        super().__init__(name, '/images', required, conditional_props,
+                         no_chain)
+
+
+class PropConfigRef(PropNodeRef):
+    """A property whose value names a node under /configurations"""
+    def __init__(self, name, required=False, conditional_props=None):
+        super().__init__(name, '/configurations', required, conditional_props)
+
+
+class PropImageRefList(PropStringList):
+    """A stringlist where each entry names a node under /images"""
+    def validate_prop(self, val, prop):
+        super().validate_prop(val, prop)
+        if isinstance(prop.value, str):
+            items = [prop.value]
+        else:
+            items = prop.value or []
+        for item in items:
+            if val.get_node('/images/' + item) is None:
+                val.fail(get_node_path(prop),
+                         f"'{prop.name}' references missing image '{item}'")
+
+
 class PropPhandleTarget(PropDesc):
     """A phandle-target property schema element
 

--- a/fit_validate/elements.py
+++ b/fit_validate/elements.py
@@ -66,13 +66,40 @@ class SchemaElement():
                 key: name of controlling property
                 value: True if the property must be present, False if it must be
                     absent
+        required_when: Dynamic requirement based on sibling values. Dict:
+                key: name of sibling property to inspect
+                value: list of values that make this element required
+            If the sibling exists and its value is in the listed values the
+            element becomes required. Otherwise the static ``required`` flag
+            applies.
     """
-    def __init__(self, name, prop_type, required=False, conditional_props=None):
+    def __init__(self, name, prop_type, required=False, conditional_props=None,
+                 required_when=None):
         self.name = name
         self.prop_type = prop_type
         self.required = required
         self.conditional_props = conditional_props
+        self.required_when = required_when
         self.parent = None
+
+    def is_required(self, node):
+        """Return True if this element is required for the given node
+
+        Args:
+            node (fdt.Node): Node being validated, used to look up sibling
+                property values for required_when
+
+        Returns:
+            bool: True if the element must be present in this node
+        """
+        if self.required:
+            return True
+        if self.required_when and node is not None:
+            for sibling_name, allowed_values in self.required_when.items():
+                sibling = node.props.get(sibling_name)
+                if sibling is not None and sibling.value in allowed_values:
+                    return True
+        return False
 
     def validate(self, val, prop_or_node):
         """Validate the schema element against the given property.
@@ -116,14 +143,26 @@ class PropString(PropDesc):
 
     Args:
         str_pattern: Regex to use to validate the string
+        values: Optional list of allowed string values. When set the value
+            must appear in the list; ``str_pattern`` is ignored.
     """
     def __init__(self, name, required=False, str_pattern='',
-                             conditional_props=None):
-        super().__init__(name, 'string', required, conditional_props)
+                             conditional_props=None, required_when=None,
+                             values=None):
+        super().__init__(name, 'string', required, conditional_props,
+                         required_when)
         self.str_pattern = str_pattern
+        self.values = values
 
     def validate_prop(self, val, prop):
-        """Check the string with a regex"""
+        """Check the string against a list of allowed values or a regex"""
+        if self.values is not None:
+            if prop.value not in self.values:
+                val.fail(
+                    get_node_path(prop),
+                    f"'{prop.name}' value '{prop.value}' is not one of "
+                    f"the allowed values ({', '.join(self.values)})")
+            return
         if not self.str_pattern:
             return
         pattern = '^' + self.str_pattern + '$'
@@ -136,8 +175,10 @@ class PropString(PropDesc):
 
 class PropInt(PropDesc):
     """Single-cell (32-bit) integer"""
-    def __init__(self, name, required=False, conditional_props=None):
-        super().__init__(name, 'int', required, conditional_props)
+    def __init__(self, name, required=False, conditional_props=None,
+                 required_when=None):
+        super().__init__(name, 'int', required, conditional_props,
+                         required_when)
 
     def validate_prop(self, val, prop):
         """Check the timestamp"""

--- a/fit_validate/elements.py
+++ b/fit_validate/elements.py
@@ -100,6 +100,17 @@ class PropDesc(SchemaElement):
         """
 
 
+class PropBytes(PropDesc):
+    """A property carrying an opaque byte sequence
+
+    Used for hash and signature values, where the bytes are produced by an
+    external tool and the validator only checks for presence (length is
+    determined by the algorithm).
+    """
+    def __init__(self, name, required=False, conditional_props=None):
+        super().__init__(name, 'bytes', required, conditional_props)
+
+
 class PropString(PropDesc):
     """A string-property
 
@@ -371,3 +382,15 @@ class NodeConfig(NodeAny):
     """A FIT config node"""
     def __init__(self, name_pattern, elements):
         super().__init__(name_pattern=name_pattern, elements=elements)
+
+
+class NodeHash(NodeAny):
+    """A FIT hash node (hash-1, hash-2, ...)"""
+    def __init__(self, elements):
+        super().__init__(name_pattern=r'hash-\d+', elements=elements)
+
+
+class NodeSignature(NodeAny):
+    """A FIT signature node (signature-1, signature-2, ...)"""
+    def __init__(self, elements):
+        super().__init__(name_pattern=r'signature-\d+', elements=elements)

--- a/fit_validate/fdt_validate.py
+++ b/fit_validate/fdt_validate.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright 2023 Google LLC
+# Written by Simon Glass <sjg@chromium.org>
+
+"""Validates a given devicetree
+
+This enforces various rules defined by the schema. Some of these are fairly
+simple (the valid properties and subnodes for each node, the allowable values
+for properties) and some are more complex (where phandles are allowed to point).
+
+The schema is defined by Python objects containing variable SchemaElement
+subclasses. Each subclass defines how the devicetree property is validated.
+For strings this is via a regex. Phandles properties are validated by the
+target they are expected to point to.
+
+Schema elements can be optional or required. Optional elements will not cause
+a failure if the node does not include them.
+
+The presence or absence of a particular schema element can also be controlled
+by a 'conditional_props' option. This lists elements that must (or must not)
+be present in the node for this element to be present. This provides some
+flexibility where the schema for a node has two options, for example, where
+the presence of one element conflicts with the presence of others.
+
+Unit tests can be run like this:
+
+    python validate_config_unittest.py
+"""
+
+import os
+
+# pylint: disable=E0401
+from dtoc import fdt, fdt_util
+from fit_validate.elements import NodeAny, NodeDesc
+from fit_validate.elements import PropAny, PropDesc
+
+class FdtValidator():
+    """Validator for the master configuration"""
+    def __init__(self, schema, raise_on_error):
+        """Master configuration validator.
+
+        Properties:
+            _errors: List of validation errors detected (each a string)
+            _fdt: fdt.Fdt object containing device tree to validate
+            _raise_on_error: True if the validator should raise on the first error
+                    (useful for debugging)
+            model_list: List of model names found in the config
+            submodel_list: Dict of submodel names found in the config:
+                    key: Model name
+                    value: List of submodel names
+        """
+        self._errors = []
+        self._fdt = None
+        self._raise_on_error = raise_on_error
+        self._schema = schema
+
+        # This iniital value matches the standard schema object. This is
+        # overwritten by the real model list by Start().
+        self.model_list = ['MODEL']
+        self.submodel_list = {}
+
+    def fail(self, location, msg):
+        """Record a validation failure
+
+        Args:
+            location (fdt.Node): where the error occurred
+            msg (str): Message to record for this failure
+        """
+        self._errors.append(f'{location}: {msg}')
+        if self._raise_on_error:
+            raise ValueError(self._errors[-1])
+
+    @staticmethod
+    def _is_builtin_property(node, prop_name):
+        """Checks if a property is a built-in device-tree construct
+
+        This checks for 'reg', '#address-cells' and '#size-cells' properties which
+        are valid when correctly used in a device-tree context.
+
+        Args:
+            node: fdt.Node where the property appears
+            prop_name: Name of the property
+
+        Returns:
+            True if this property is a built-in property and does not have to be
+            covered by the schema
+        """
+        if prop_name == 'reg' and '@' in node.name:
+            return True
+        if prop_name in ['#address-cells', '#size-cells']:
+            for subnode in node.subnodes:
+                if '@' in subnode.name:
+                    return True
+        return False
+
+    @staticmethod
+    def element_present(schema, parent_node):
+        """Check whether a schema element should be present
+
+        This handles the conditional_props feature. The list of names of sibling
+        nodes/properties that are actually present is checked to see if any of them
+        conflict with the conditional properties for this node. If there is a
+        conflict, then this element is considered to be absent.
+
+        Args:
+            schema (SchemaElement): Schema element to check
+            parent_node (fdt.Node): Parent node containing this schema element
+                (or None if this is not known)
+
+        Returns:
+            True if this element is present, False if absent
+        """
+        if schema.conditional_props and parent_node:
+            for rel_name, value in schema.conditional_props.items():
+                name = rel_name
+                schema_target = schema.parent
+                node_target = parent_node
+                while name.startswith('../'):
+                    schema_target = schema_target.parent
+                    node_target = node_target.parent
+                    name = name[3:]
+                parent_props = [e.name for e in schema_target.elements]
+                sibling_names = set(node_target.props.keys())
+                sibling_names |= set(n.name for n in node_target.subnodes)
+                if name in parent_props and value != (name in sibling_names):
+                    return False
+        return True
+
+    def get_element(self, schema, name, node, expected=None):
+        """Get an element from the schema by name
+
+        Args:
+            schema (SchemaElement): Schema element to check
+            name (str): Name of element to find
+            node (fdt.Node): Node containing the property (or for nodes, the
+                parent node containing the subnode) we are looking up. None if
+                none available
+            expected (SchemaElement): The  object that is expected. This can be
+                NodeDesc if a node is expected, PropDesc if a property is
+                expected, or None if either is fine.
+
+        Returns:
+            Tuple:
+                Schema for the node, or None if none found
+                True if the node should have schema, False if it can be ignored
+                    (because it is internal to the device-tree format)
+        """
+        for element in schema.elements:
+            if not self.element_present(element, node):
+                continue
+            if element.name == name:
+                return element, True
+            if ((expected is None or expected == NodeDesc) and
+                        isinstance(element, NodeAny)):
+                return element, True
+            if ((expected is None or expected == PropDesc) and
+                        isinstance(element, PropAny)):
+                return element, True
+        if expected == PropDesc:
+            if name == 'linux,phandle' or self._is_builtin_property(node, name):
+                return None, False
+        return None, True
+
+    def get_element_by_path(self, path):
+        """Find a schema element given its full path
+
+        Args:
+            path (str): Full path to look up (e.g.
+                '/chromeos/models/MODEL/thermal/dptf-dv')
+
+        Returns:
+            SchemaElement object for that path
+
+        Raises:
+            AttributeError if not found
+        """
+        parts = path.split('/')[1:]
+        schema = self._schema
+        for part in parts:
+            element, _ = self.get_element(schema, part, None)
+            schema = element
+        return schema
+
+    def _validate_schema(self, node, schema):
+        """Simple validation of properties.
+
+        This only handles simple mistakes like getting the name wrong. It
+        cannot handle relationships between different properties.
+
+        Args:
+            node: fdt.Node where the property appears
+            schema: NodeDesc containing schema for this node
+        """
+        schema.validate(self, node)
+        schema_props = [e.name for e in schema.elements
+                                        if isinstance(e, PropDesc) and
+                                        self.element_present(e, node)]
+
+        # Validate each property and check that there are no extra properties not
+        # mentioned in the schema.
+        for prop_name in node.props.keys():
+            if prop_name == 'linux,phandle':    # Ignore this (use 'phandle' instead)
+                continue
+            element, _ = self.get_element(schema, prop_name, node, PropDesc)
+            if not element or not isinstance(element, PropDesc):
+                if prop_name == 'phandle':
+                    self.fail(node.path, 'phandle target not valid for this node')
+                elif not self._is_builtin_property(node, prop_name):
+                    self.fail(
+                        node.path,
+                        f"Unexpected property '{prop_name}', valid list is "
+                        f"({', '.join(schema_props)})")
+                continue
+            element.validate(self, node.props[prop_name])
+
+        # Check that there are no required properties which we don't have
+        for element in schema.elements:
+            if (not isinstance(element, PropDesc) or
+                    not self.element_present(element, node)):
+                continue
+            if element.required and element.name not in node.props.keys():
+                self.fail(
+                    node.path,
+                    f"Required property '{element.name}' missing")
+
+        # Check that any required subnodes are present
+        subnode_names = [n.name for n in node.subnodes]
+        for element in schema.elements:
+            if (not isinstance(element, NodeDesc) or not element.required
+                    or not self.element_present(element, node)):
+                continue
+            if element.name not in subnode_names:
+                msg = f"Missing subnode '{element.name}'"
+                if subnode_names:
+                    msg += f" in {', '.join(subnode_names)}"
+                self.fail(node.path, msg)
+
+    def get_schema(self, node, parent_schema):
+        """Obtain the schema for a subnode
+
+        This finds the schema for a subnode, by scanning for a matching element.
+
+        Args:
+            node (fdt.Node): Node whose schema we are searching for
+            parent_schema (NodeDesc): Schema for the parent node, which
+                contains that schema
+
+        Returns:
+            Schema for the node, or None if none found
+        """
+        schema, needed = self.get_element(parent_schema, node.name, node.parent,
+                                                                         NodeDesc)
+        if not schema and needed:
+            elements = [e.name for e in parent_schema.get_nodes()
+                        if self.element_present(e, node.parent)]
+            self.fail(os.path.dirname(node.path),
+                      f"Unexpected subnode '{node.name}', valid list is "
+                      f"({', '.join(elements)})")
+        return schema
+
+    def _validate_tree(self, node, parent_schema):
+        """Validate a node and all its subnodes recursively
+
+        Args:
+            node: name of fdt.Node to search for
+            parent_schema: Schema for the parent node
+        """
+        if node.name == '/':
+            schema = parent_schema
+        else:
+            schema = self.get_schema(node, parent_schema)
+            if schema is None:
+                return
+
+        self._validate_schema(node, schema)
+        for subnode in node.subnodes:
+            self._validate_tree(subnode, schema)
+
+    def prepare(self, _fdt):
+        """Prepare to validate"""
+        self._fdt = _fdt
+
+
+    def start(self, fname):
+        """Start validating a master configuration file
+
+        Args:
+            fname (str): Filename of devicetree to validate.
+                Supports compiled .dtb, source .dts and README.md (which
+                has configuration source between ``` markers)
+
+        Returns:
+            list of str: List of errors found
+        """
+        self.model_list = []
+        self.submodel_list = {}
+        self._errors = []
+        dtb = fdt_util.EnsureCompiled(fname)
+        self.prepare(fdt.FdtScan(dtb))
+
+        # Validate the entire master configuration
+        self._validate_tree(self._fdt.GetRoot(), self._schema)
+        return self._errors

--- a/fit_validate/fdt_validate.py
+++ b/fit_validate/fdt_validate.py
@@ -241,7 +241,8 @@ class FdtValidator():
             if (not isinstance(element, PropDesc) or
                     not self.element_present(element, node)):
                 continue
-            if element.required and element.name not in node.props.keys():
+            if (element.is_required(node)
+                    and element.name not in node.props.keys()):
                 self.fail(
                     node.path,
                     f"Required property '{element.name}' missing")
@@ -249,7 +250,8 @@ class FdtValidator():
         # Check that any required subnodes are present
         subnode_names = [n.name for n in node.subnodes]
         for element in schema.elements:
-            if (not isinstance(element, NodeDesc) or not element.required
+            if (not isinstance(element, NodeDesc)
+                    or not element.is_required(node)
                     or not self.element_present(element, node)):
                 continue
             if element.name not in subnode_names:

--- a/fit_validate/fdt_validate.py
+++ b/fit_validate/fdt_validate.py
@@ -202,6 +202,14 @@ class FdtValidator():
         for prop_name in node.props.keys():
             if prop_name == 'linux,phandle':    # Ignore this (use 'phandle' instead)
                 continue
+            stripped = prop_name.strip()
+            if stripped != prop_name:
+                msg = (f"Property name '{prop_name}' has surrounding "
+                       f"whitespace; check the tool that produced this FIT")
+                if stripped and stripped in schema_props:
+                    msg += f" (did you mean '{stripped}'?)"
+                self.fail(node.path, msg)
+                continue
             element, _ = self.get_element(schema, prop_name, node, PropDesc)
             if not element or not isinstance(element, PropDesc):
                 if prop_name == 'phandle':

--- a/fit_validate/fdt_validate.py
+++ b/fit_validate/fdt_validate.py
@@ -303,6 +303,19 @@ class FdtValidator():
         """Prepare to validate"""
         self._fdt = _fdt
 
+    def get_node(self, path):
+        """Look up a node by full path
+
+        Args:
+            path (str): Full devicetree path (e.g. '/images/image-1')
+
+        Returns:
+            fdt.Node, or None if no such node exists
+        """
+        if self._fdt is None:
+            return None
+        return self._fdt.GetNode(path)
+
 
     def start(self, fname):
         """Start validating a master configuration file

--- a/fit_validate/fdt_validate.py
+++ b/fit_validate/fdt_validate.py
@@ -29,6 +29,7 @@ Unit tests can be run like this:
 """
 
 import os
+import re
 
 # pylint: disable=E0401
 from dtoc import fdt, fdt_util
@@ -146,6 +147,15 @@ class FdtValidator():
                 True if the node should have schema, False if it can be ignored
                     (because it is internal to the device-tree format)
         """
+        # When more than one NodeAny sibling defines a name pattern, pick
+        # the one whose pattern matches. With a single NodeAny we keep the
+        # historic behaviour of accepting any name and letting validate_node
+        # report the pattern mismatch.
+        patterned_anys = [e for e in schema.elements
+                          if (isinstance(e, NodeAny) and e.name_pattern
+                              and self.element_present(e, node))]
+        filter_by_pattern = len(patterned_anys) > 1
+
         for element in schema.elements:
             if not self.element_present(element, node):
                 continue
@@ -153,6 +163,10 @@ class FdtValidator():
                 return element, True
             if ((expected is None or expected == NodeDesc) and
                         isinstance(element, NodeAny)):
+                if filter_by_pattern and element.name_pattern:
+                    if re.match('^' + element.name_pattern + '$', name):
+                        return element, True
+                    continue
                 return element, True
             if ((expected is None or expected == PropDesc) and
                         isinstance(element, PropAny)):

--- a/fit_validate/schema.py
+++ b/fit_validate/schema.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright 2023 Google LLC
+# Written by Simon Glass <sjg@chromium.org>
+
+"""This is the schema. It is a hierarchical set of nodes and properties, just
+like the device tree. If an object subclasses NodeDesc then it is a node,
+possibly with properties and subnodes.
+
+In this way it is possible to describe the schema in a fairly natural,
+hierarchical way.
+"""
+
+from fit_validate.elements import NodeDesc, NodeConfig, NodeImage
+from fit_validate.elements import PropAddressCells, PropBool, PropDesc, PropInt
+from fit_validate.elements import PropString, PropStringList, PropTimestamp
+
+
+def get_schema(upl=False):
+    """Get the schema to use
+
+    Args:
+        upl (bool): True to get the schema for Universal Payload; False to get
+            the schema for FIT
+    """
+    node_image = NodeImage(r'image-\d+' if upl else r'[a-z-]+-\d+', elements=[
+        PropString('description', True),
+        PropTimestamp('timestamp'),
+        PropString('arch', True),
+        PropString('type', True),
+        PropString('compression'),
+        PropInt('data-offset', True, conditional_props={'data': False}),
+        PropInt('data-size', True, conditional_props={'data': False}),
+        PropDesc('data', True,
+                 conditional_props={'data-offset': False,
+                                    'data-size': False}),
+        PropString('os', True),
+        PropInt('load'),
+        PropStringList('capabilities'),
+        PropString('producer'),
+        PropInt('uncomp-size'),
+        PropInt('entry-start', False),
+        PropInt('entry', False),
+        PropInt('reloc-start', False),
+    ])
+
+    node_config = NodeConfig(r'config-\d+' if upl else r'conf-\d+', elements=[
+        PropString('description', True),
+        PropString('fdt'),  # Add
+        PropStringList('loadables'),
+        PropStringList('compatible'),
+        PropBool('require-fit'),
+    ])
+
+    schema = NodeDesc('/', True, [
+        PropTimestamp('timestamp', True),
+        PropString('description', True),
+        PropAddressCells(True),
+        NodeDesc('images', True, [
+            node_image,
+        ]),
+        NodeDesc('configurations', True, [
+            PropString('default'),
+            node_config,
+        ]),
+    ])
+
+    # Tweak the base schema as needed for UPL/vanilla variants
+    if upl:
+        node_image.add_element(PropString('project', True))
+        node_config.add_element(PropString('firmware', True))
+    else:
+        node_config.add_element(PropString('kernel', True))
+        node_config.add_element(PropString('ramdisk'))
+
+    return schema

--- a/fit_validate/schema.py
+++ b/fit_validate/schema.py
@@ -14,8 +14,9 @@ hierarchical way.
 from fit_validate.elements import NodeConfig, NodeDesc, NodeHash, NodeImage
 from fit_validate.elements import NodeSignature
 from fit_validate.elements import PropAddressCells, PropBool, PropBytes
-from fit_validate.elements import PropDesc, PropInt, PropString, PropStringList
-from fit_validate.elements import PropTimestamp
+from fit_validate.elements import PropConfigRef, PropDesc, PropImageRef
+from fit_validate.elements import PropImageRefList, PropInt, PropString
+from fit_validate.elements import PropStringList, PropTimestamp
 
 
 # Hash algorithms accepted on a hash-N node (chapter 5, Hash nodes).
@@ -51,7 +52,7 @@ def _image_signature_node():
         PropBytes('value', True),
         PropStringList('hashed-nodes', True),
         PropBytes('hashed-strings', True),
-        PropStringList('sign-images'),
+        PropImageRefList('sign-images'),
         PropTimestamp('timestamp'),
         PropString('signer-name'),
         PropString('signer-version'),
@@ -70,7 +71,7 @@ def _config_signature_node():
         PropString('algo', True, str_pattern=SIGNATURE_ALGO),
         PropString('key-name-hint', True),
         PropBytes('value', True),
-        PropStringList('sign-images'),
+        PropImageRefList('sign-images'),
         PropBytes('hashed-strings'),
         PropTimestamp('timestamp'),
         PropString('signer-name'),
@@ -93,11 +94,13 @@ def get_schema(upl=False):
         PropString('arch', True),
         PropString('type', True),
         PropString('compression'),
-        PropInt('data-offset', True, conditional_props={'data': False}),
-        PropInt('data-size', True, conditional_props={'data': False}),
-        PropDesc('data', True,
-                 conditional_props={'data-offset': False,
-                                    'data-size': False}),
+        PropInt('data-offset', True, conditional_props={
+            'data': False, 'image-data': False}),
+        PropInt('data-size', True, conditional_props={
+            'data': False, 'image-data': False}),
+        PropDesc('data', True, conditional_props={
+            'data-offset': False, 'data-size': False, 'image-data': False}),
+        PropImageRef('image-data', no_chain=True),
         PropString('os', True),
         PropInt('load'),
         PropStringList('capabilities'),
@@ -112,8 +115,8 @@ def get_schema(upl=False):
 
     node_config = NodeConfig(r'config-\d+' if upl else r'conf-\d+', elements=[
         PropString('description', True),
-        PropString('fdt'),  # Add
-        PropStringList('loadables'),
+        PropImageRef('fdt'),
+        PropImageRefList('loadables'),
         PropStringList('compatible'),
         PropBool('require-fit'),
         _config_signature_node(),
@@ -127,7 +130,7 @@ def get_schema(upl=False):
             node_image,
         ]),
         NodeDesc('configurations', True, [
-            PropString('default'),
+            PropConfigRef('default'),
             node_config,
         ]),
     ])
@@ -135,9 +138,9 @@ def get_schema(upl=False):
     # Tweak the base schema as needed for UPL/vanilla variants
     if upl:
         node_image.add_element(PropString('project', True))
-        node_config.add_element(PropString('firmware', True))
+        node_config.add_element(PropImageRef('firmware', True))
     else:
-        node_config.add_element(PropString('kernel', True))
-        node_config.add_element(PropString('ramdisk'))
+        node_config.add_element(PropImageRef('kernel', True))
+        node_config.add_element(PropImageRef('ramdisk'))
 
     return schema

--- a/fit_validate/schema.py
+++ b/fit_validate/schema.py
@@ -57,6 +57,9 @@ ARCH_REQUIRED_TYPES = ['standalone', 'kernel', 'firmware', 'ramdisk', 'fdt']
 # Image types for which 'entry' and 'load' are mandatory (chapter 5).
 LOAD_REQUIRED_TYPES = ['firmware', 'kernel']
 
+# Allowed values for the U-Boot 'phase' property (chapter 5).
+PHASE_VALUES = ['spl', 'u-boot']
+
 # Hash algorithms accepted on a hash-N node (chapter 5, Hash nodes).
 HASH_ALGO = r'crc16-ccitt|crc32|md5|sha1|sha256|sha384|sha512'
 
@@ -134,11 +137,13 @@ def get_schema(upl=False):
                    required_when={'type': ARCH_REQUIRED_TYPES}),
         PropString('compression', values=COMPRESSION_TYPES),
         PropInt('data-offset', True, conditional_props={
-            'data': False, 'image-data': False}),
+            'data': False, 'image-data': False, 'data-position': False}),
         PropInt('data-size', True, conditional_props={
             'data': False, 'image-data': False}),
         PropDesc('data', True, conditional_props={
-            'data-offset': False, 'data-size': False, 'image-data': False}),
+            'data-offset': False, 'data-size': False, 'image-data': False,
+            'data-position': False}),
+        PropInt('data-position'),
         PropImageRef('image-data', no_chain=True),
         PropString('os', values=OS_NAMES,
                    required_when={'type': ['kernel']}),
@@ -149,6 +154,12 @@ def get_schema(upl=False):
         PropInt('entry-start', False),
         PropInt('entry', required_when={'type': LOAD_REQUIRED_TYPES}),
         PropInt('reloc-start', False),
+        # 'compatible' on an image carries the loading-method string for
+        # fpga images (and images without a load address). Spec lists only
+        # the fpga methods explicitly, so leave the value set open.
+        PropStringList('compatible',
+                       required_when={'type': ['fpga']}),
+        PropString('phase', values=PHASE_VALUES),
         _hash_node(),
         _image_signature_node(),
     ])
@@ -156,8 +167,12 @@ def get_schema(upl=False):
     node_config = NodeConfig(r'config-\d+' if upl else r'conf-\d+', elements=[
         PropString('description', True),
         PropImageRef('fdt'),
+        PropImageRef('fpga'),
+        PropImageRef('script'),
         PropImageRefList('loadables'),
         PropStringList('compatible'),
+        PropString('cmdline'),
+        PropBool('load-only'),
         PropBool('require-fit'),
         _config_signature_node(),
     ])

--- a/fit_validate/schema.py
+++ b/fit_validate/schema.py
@@ -11,9 +11,73 @@ In this way it is possible to describe the schema in a fairly natural,
 hierarchical way.
 """
 
-from fit_validate.elements import NodeDesc, NodeConfig, NodeImage
-from fit_validate.elements import PropAddressCells, PropBool, PropDesc, PropInt
-from fit_validate.elements import PropString, PropStringList, PropTimestamp
+from fit_validate.elements import NodeConfig, NodeDesc, NodeHash, NodeImage
+from fit_validate.elements import NodeSignature
+from fit_validate.elements import PropAddressCells, PropBool, PropBytes
+from fit_validate.elements import PropDesc, PropInt, PropString, PropStringList
+from fit_validate.elements import PropTimestamp
+
+
+# Hash algorithms accepted on a hash-N node (chapter 5, Hash nodes).
+HASH_ALGO = r'crc16-ccitt|crc32|md5|sha1|sha256|sha384|sha512'
+
+# Signature algorithms are a composite '<hash>,<signing>' string (chapter 5,
+# Image-signature nodes). The spec lists explicit combinations but explains
+# that any hash may be paired with any signing algorithm, so allow any
+# rsaNNNN or ecdsaNNNN paired with one of the supported hashes.
+SIGNATURE_ALGO = r'(sha1|sha256|sha384|sha512),(rsa\d+|ecdsa\d+)'
+
+# Padding modes for signature nodes.
+SIGNATURE_PADDING = r'pkcs-1\.5|pss'
+
+
+def _hash_node():
+    """Build a hash-N node schema element"""
+    return NodeHash(elements=[
+        PropString('algo', True, str_pattern=HASH_ALGO),
+        PropBytes('value', True),
+    ])
+
+
+def _image_signature_node():
+    """Build a signature-N schema element for use under an image node
+
+    Per the spec, in a fully-signed image these properties are mandatory:
+    algo, key-name-hint, value, hashed-nodes, hashed-strings.
+    """
+    return NodeSignature(elements=[
+        PropString('algo', True, str_pattern=SIGNATURE_ALGO),
+        PropString('key-name-hint', True),
+        PropBytes('value', True),
+        PropStringList('hashed-nodes', True),
+        PropBytes('hashed-strings', True),
+        PropStringList('sign-images'),
+        PropTimestamp('timestamp'),
+        PropString('signer-name'),
+        PropString('signer-version'),
+        PropString('comment'),
+        PropString('padding', str_pattern=SIGNATURE_PADDING),
+    ])
+
+
+def _config_signature_node():
+    """Build a signature-N schema element for use under a config node
+
+    Per the spec, in a fully-signed config only algo, key-name-hint and
+    value are mandatory; sign-images and hashed-strings are optional.
+    """
+    return NodeSignature(elements=[
+        PropString('algo', True, str_pattern=SIGNATURE_ALGO),
+        PropString('key-name-hint', True),
+        PropBytes('value', True),
+        PropStringList('sign-images'),
+        PropBytes('hashed-strings'),
+        PropTimestamp('timestamp'),
+        PropString('signer-name'),
+        PropString('signer-version'),
+        PropString('comment'),
+        PropString('padding', str_pattern=SIGNATURE_PADDING),
+    ])
 
 
 def get_schema(upl=False):
@@ -42,6 +106,8 @@ def get_schema(upl=False):
         PropInt('entry-start', False),
         PropInt('entry', False),
         PropInt('reloc-start', False),
+        _hash_node(),
+        _image_signature_node(),
     ])
 
     node_config = NodeConfig(r'config-\d+' if upl else r'conf-\d+', elements=[
@@ -50,6 +116,7 @@ def get_schema(upl=False):
         PropStringList('loadables'),
         PropStringList('compatible'),
         PropBool('require-fit'),
+        _config_signature_node(),
     ])
 
     schema = NodeDesc('/', True, [

--- a/fit_validate/schema.py
+++ b/fit_validate/schema.py
@@ -19,6 +19,44 @@ from fit_validate.elements import PropImageRefList, PropInt, PropString
 from fit_validate.elements import PropStringList, PropTimestamp
 
 
+# Allowed values for image 'type' (chapter 5).
+IMAGE_TYPES = [
+    'invalid', 'aisimage', 'atmelimage', 'copro', 'fdt_legacy', 'filesystem',
+    'firmware', 'firmware_ivt', 'flat_dt', 'flat-binary', 'fpga', 'gpimage',
+    'imx8image', 'imx8mimage', 'imximage', 'kernel', 'kernel_noload',
+    'kwbimage', 'lpc32xximage', 'mtk_image', 'multi', 'mxsimage',
+    'omapimage', 'pblimage', 'pmmc', 'ramdisk', 'rkimage', 'rksd',
+    'rkspi', 'script', 'socfpgaimage', 'socfpgaimage_v1', 'spkgimage',
+    'standalone', 'stm32image', 'sunxi_egon', 'sunxi_toc0', 'tee',
+    'tfa-bl31', 'ublimage', 'vybridimage', 'x86_setup', 'zynqimage',
+    'zynqmpbif', 'zynqmpimage',
+]
+
+# Allowed values for 'compression' on an image (chapter 5).
+COMPRESSION_TYPES = ['none', 'bzip2', 'gzip', 'lz4', 'lzma', 'lzo', 'zstd']
+
+# Allowed values for 'os' on an image (chapter 5).
+OS_NAMES = [
+    'invalid', '4_4bsd', 'arm-trusted-firmware', 'dell', 'efi', 'esix',
+    'freebsd', 'integrity', 'irix', 'linux', 'ncr', 'netbsd', 'openbsd',
+    'openrtos', 'opensbi', 'ose', 'plan9', 'psos', 'qnx', 'rtems', 'sco',
+    'solaris', 'svr4', 'tee', 'u-boot', 'vxworks',
+]
+
+# Allowed values for 'arch' on an image (chapter 5).
+ARCH_NAMES = [
+    'invalid', 'alpha', 'arc', 'arm64', 'arm', 'avr32', 'blackfin', 'ia64',
+    'm68k', 'microblaze', 'mips64', 'mips', 'nds32', 'nios2', 'or1k',
+    'powerpc', 'ppc', 'riscv', 's390', 'sandbox', 'sh', 'sparc64', 'sparc',
+    'x86_64', 'x86', 'xtensa',
+]
+
+# Image types for which 'arch' is mandatory (chapter 5).
+ARCH_REQUIRED_TYPES = ['standalone', 'kernel', 'firmware', 'ramdisk', 'fdt']
+
+# Image types for which 'entry' and 'load' are mandatory (chapter 5).
+LOAD_REQUIRED_TYPES = ['firmware', 'kernel']
+
 # Hash algorithms accepted on a hash-N node (chapter 5, Hash nodes).
 HASH_ALGO = r'crc16-ccitt|crc32|md5|sha1|sha256|sha384|sha512'
 
@@ -91,9 +129,10 @@ def get_schema(upl=False):
     node_image = NodeImage(r'image-\d+' if upl else r'[a-z-]+-\d+', elements=[
         PropString('description', True),
         PropTimestamp('timestamp'),
-        PropString('arch', True),
-        PropString('type', True),
-        PropString('compression'),
+        PropString('type', True, values=IMAGE_TYPES),
+        PropString('arch', values=ARCH_NAMES,
+                   required_when={'type': ARCH_REQUIRED_TYPES}),
+        PropString('compression', values=COMPRESSION_TYPES),
         PropInt('data-offset', True, conditional_props={
             'data': False, 'image-data': False}),
         PropInt('data-size', True, conditional_props={
@@ -101,13 +140,14 @@ def get_schema(upl=False):
         PropDesc('data', True, conditional_props={
             'data-offset': False, 'data-size': False, 'image-data': False}),
         PropImageRef('image-data', no_chain=True),
-        PropString('os', True),
-        PropInt('load'),
+        PropString('os', values=OS_NAMES,
+                   required_when={'type': ['kernel']}),
+        PropInt('load', required_when={'type': LOAD_REQUIRED_TYPES}),
         PropStringList('capabilities'),
         PropString('producer'),
         PropInt('uncomp-size'),
         PropInt('entry-start', False),
-        PropInt('entry', False),
+        PropInt('entry', required_when={'type': LOAD_REQUIRED_TYPES}),
         PropInt('reloc-start', False),
         _hash_node(),
         _image_signature_node(),
@@ -124,7 +164,7 @@ def get_schema(upl=False):
 
     schema = NodeDesc('/', True, [
         PropTimestamp('timestamp', True),
-        PropString('description', True),
+        PropString('description'),
         PropAddressCells(True),
         NodeDesc('images', True, [
             node_image,

--- a/fit_validate/schema.py
+++ b/fit_validate/schema.py
@@ -173,7 +173,6 @@ def get_schema(upl=False):
         PropStringList('compatible'),
         PropString('cmdline'),
         PropBool('load-only'),
-        PropBool('require-fit'),
         _config_signature_node(),
     ])
 
@@ -190,10 +189,12 @@ def get_schema(upl=False):
         ]),
     ])
 
-    # Tweak the base schema as needed for UPL/vanilla variants
+    # Tweak the base schema as needed for UPL/vanilla variants. require-fit
+    # is a UPL extension and is not part of the FIT specification.
     if upl:
         node_image.add_element(PropString('project', True))
         node_config.add_element(PropImageRef('firmware', True))
+        node_config.add_element(PropBool('require-fit'))
     else:
         node_config.add_element(PropImageRef('kernel', True))
         node_config.add_element(PropImageRef('ramdisk'))

--- a/fit_validate/validate.py
+++ b/fit_validate/validate.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright 2023 Google LLC
+# Written by Simon Glass <sjg@chromium.org>
+
+"""Flat Image Tree (FIT) validator
+
+This does not use dtschema, at least for now, since:
+
+- it does not have bindings for FIT
+- the errors dtschema shows when things go wrong are verbose and confusing
+- the dtschema validation is not powerful enough for checking configurations and
+  other relations between nodes
+"""
+
+import argparse
+import os
+import sys
+
+if __name__ == "__main__":
+    # Allow 'from validate import xxx to work'
+    our_path = os.path.dirname(os.path.realpath(__file__))
+    sys.path.append(os.path.join(our_path, '..'))
+
+    sys.path.append(os.path.join(our_path, '/home/sglass/u/tools'))
+
+# pylint: disable=C0413,E0401
+from u_boot_pylib import tools
+from fit_validate import schema
+from fit_validate import fdt_validate
+
+
+def parse_args(argv):
+    """Parse arguments to the program
+
+    Args:
+        argv (list of str): List of arguments to parse (without argv[0])
+
+    Returns:
+        Namespace: Parsed arguments
+    """
+    epilog = 'Validate Flat Image Tree (FIT) files'
+    parser = argparse.ArgumentParser(epilog=epilog)
+    parser.add_argument(
+        '-r', '--raise-on-error', action='store_true',
+        help='Causes the validator to raise on the first error it finds; '
+             'useful for debugging')
+    parser.add_argument(
+        '-u', '--upl', action='store_true',
+        help='Use the Universal Payload (UPL) schema instead of FIT')
+    parser.add_argument('files', type=str, nargs='*', help='Files to validate')
+    # parser.add_argument('-U', '--show-environment', action='store_true',
+          # default=False, help='Show environment changes in summary')
+
+    return parser.parse_args(argv)
+
+
+def show_errors(fname, errors):
+    """Show validation errors
+
+    Args:
+        fname (str): Filename containing the errors
+        errors (list of str): List of errors
+    """
+    print(f'{fname}:', file=sys.stderr)
+    for error in errors:
+        print(error, file=sys.stderr)
+    print(file=sys.stderr)
+
+
+def run_fit_validate(argv=None):
+    """Main program for FIT validator
+
+    This validates each of the provided files and prints the errors for each, if
+    any.
+
+    Args:
+      argv (list of str): Arguments to the problem (excluding argv[0]); if None,
+         uses sys.argv
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+    args = parse_args(argv)
+    tools.prepare_output_dir(None)
+    validator = fdt_validate.FdtValidator(schema.get_schema(args.upl),
+                                          args.raise_on_error)
+    found_errors = False
+    try:
+        for fname in args.files:
+            errors = validator.start(fname)
+            if errors:
+                found_errors = True
+            if errors:
+                show_errors(fname, errors)
+                found_errors = True
+    except ValueError as exc:
+        if args.debug:
+            raise
+        print(f'Failed: {exc}', file=sys.stderr)
+        found_errors = True
+    tools.finalise_output_dir()
+    if found_errors:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_fit_validate())

--- a/fit_validate/validate.py
+++ b/fit_validate/validate.py
@@ -48,7 +48,9 @@ def parse_args(argv):
              'useful for debugging')
     parser.add_argument(
         '-u', '--upl', action='store_true',
-        help='Use the Universal Payload (UPL) schema instead of FIT')
+        help='Force the Universal Payload (UPL) schema for every file. '
+             'When unset, files with a .upl extension are validated as UPL '
+             'and the rest as plain FIT.')
     parser.add_argument('files', type=str, nargs='*', help='Files to validate')
     # parser.add_argument('-U', '--show-environment', action='store_true',
           # default=False, help='Show environment changes in summary')
@@ -83,14 +85,15 @@ def run_fit_validate(argv=None):
         argv = sys.argv[1:]
     args = parse_args(argv)
     tools.prepare_output_dir(None)
-    validator = fdt_validate.FdtValidator(schema.get_schema(args.upl),
-                                          args.raise_on_error)
+    fit_schema = schema.get_schema(False)
+    upl_schema = schema.get_schema(True)
     found_errors = False
     try:
         for fname in args.files:
+            use_upl = args.upl or fname.lower().endswith('.upl')
+            validator = fdt_validate.FdtValidator(
+                upl_schema if use_upl else fit_schema, args.raise_on_error)
             errors = validator.start(fname)
-            if errors:
-                found_errors = True
             if errors:
                 show_errors(fname, errors)
                 found_errors = True

--- a/fit_validate/validate_test.py
+++ b/fit_validate/validate_test.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright 2023 Google LLC
+# Written by Simon Glass <sjg@chromium.org>
+
+"""Unit tests for the config validator"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+if __name__ == "__main__":
+    # Allow 'from validate import xxx to work'
+    our_path = os.path.dirname(os.path.realpath(__file__))
+    sys.path.append(os.path.join(our_path, '..'))
+
+    sys.path.append(os.path.join(our_path, '/home/sglass/u/tools'))
+
+# pylint: disable=C0413,E0401
+from u_boot_pylib import tools
+from fit_validate import schema
+from fit_validate import fdt_validate
+
+HEADER = '''/dts-v1/;
+
+/ {
+    timestamp = <123456>;
+    description = "This is my description";
+    #address-cells = <1>;
+    images {
+        image-1 {
+            description = "Image description";
+            arch = "arm64";
+            type = "kernel";
+            data = "abc";
+            os = "linux";
+            project = "linux";
+        };
+    };
+
+    configurations {
+        config-1 {
+            description = "Configuration description";
+            firmware = "image-1";
+        };
+    };
+};
+'''
+
+EXTRA = '''
+/ {
+    wibble {
+        something;
+    };
+
+    images {
+        extra-prop;
+    };
+};
+'''
+
+class UnitTests(unittest.TestCase):
+    """Unit tests for FdtValidator
+
+    Properties:
+        val: Validator to use
+        returncode: Holds the return code for the case where the validator is
+            called through its command-line interface
+    """
+    def setUp(self):
+        self.val = fdt_validate.FdtValidator(schema.get_schema(True), False)
+        self.returncode = 0
+
+    def run_test(self, dts_source, use_command_line=False, extra_options=None):
+        """Run the validator with a single source file
+
+        Args:
+            dts_source (str): Device-tree source to process
+            use_command_line (bool): True to run through the command-line
+                interface. Otherwise the imported validator class is used
+                directly. When using the command-line interface, the return
+                code  is available in self.returncode, since only one test
+                needs it.
+            extra_options (list of str): Extra command-line arguments to pass
+        """
+        with tempfile.NamedTemporaryFile(suffix='.dts', delete=False) as dts:
+            dts.write(dts_source.encode('utf-8'))
+            dts.close()
+            self.returncode = 0
+            if use_command_line:
+                call_args = ['python', '-m', 'fit_validate.validate', dts.name]
+                if extra_options:
+                    call_args += extra_options
+                try:
+                    output = subprocess.check_output(call_args,
+                                                    stderr=subprocess.STDOUT)
+                except subprocess.CalledProcessError as exc:
+                    output = exc.output
+                    self.returncode = exc.returncode
+                errors = output.strip().splitlines()
+            else:
+                tools.prepare_output_dir(None)
+                errors = self.val.start(dts.name)
+                tools.finalise_output_dir()
+            if errors:
+                return errors
+            os.unlink(dts.name)
+        return []
+
+    def _check_all_in(self, err_msg_list, result_lines):
+        """Check that the given messages appear in the validation result
+
+        All messages must appear, and all lines must be matches.
+
+        Args:
+            result_lines: List of validation results to check, each a string
+            err_msg_list: List of error messages to check for
+        """
+        err_msg_set = set(err_msg_list)
+        for line in result_lines:
+            found = False
+            for err_msg in err_msg_set:
+                if err_msg in line:
+                    err_msg_set.remove(err_msg)
+                    found = True
+                    break
+            if not found:
+                self.fail(f'Found unexpected result: {line}')
+        if err_msg_set:
+            self.fail("Expected '%s'\n but not found in result: %s" %
+                                (err_msg_set.pop(), '\n'.join(result_lines)))
+
+    def test_base(self):
+        """Test a skeleton file"""
+        self.assertEqual([], self.run_test(HEADER))
+
+    def test_missing(self):
+        """Test complaining about missing properties"""
+        lines = [line for line in HEADER.splitlines()
+                 if 'project' not in line and 'firmware' not in line]
+        missing_dt = '\n'.join(lines)
+        result = self.run_test(missing_dt)
+        self._check_all_in([
+                "/images/image-1: Required property 'project' missing",
+                "/configurations/config-1: Required property 'firmware' missing",
+                ], result)
+
+    def test_comannd_line(self):
+        """Test that the command-line interface works correctly"""
+        self.assertEqual([], self.run_test(HEADER, True, ['-u']))
+
+    def test_extra(self):
+        """Test complaining about extra nodes and properties"""
+        result = self.run_test(HEADER + EXTRA)
+        self.assertEqual(
+            ["/images: Unexpected property 'extra-prop', valid list is ()",
+             "/: Unexpected subnode 'wibble', valid list is (images, configurations)"],
+             result)
+
+
+if __name__ == '__main__':
+    unittest.main(module=__name__)

--- a/fit_validate/validate_test.py
+++ b/fit_validate/validate_test.py
@@ -203,6 +203,57 @@ class UnitTests(unittest.TestCase):
         """Test that the command-line interface works correctly"""
         self.assertEqual([], self.run_test(HEADER, True, ['-u']))
 
+    def test_upl_extension_selects_upl_schema(self):
+        """A .upl file is validated against the UPL schema automatically
+
+        The fixture uses HEADER, which exercises UPL-only properties such as
+        ``project``. Run it through the command-line interface using a .upl
+        suffix and without the -u flag - validation should still succeed.
+        """
+        with tempfile.NamedTemporaryFile(suffix='.upl', delete=False) as upl:
+            upl.close()
+        with tempfile.NamedTemporaryFile(suffix='.dts', delete=False) as dts:
+            dts.write(HEADER.encode('utf-8'))
+            dts.close()
+            tools.prepare_output_dir(None)
+            from dtoc import fdt_util
+            dtb = fdt_util.EnsureCompiled(dts.name)
+            with open(dtb, 'rb') as src, open(upl.name, 'wb') as dst:
+                dst.write(src.read())
+            tools.finalise_output_dir()
+            os.unlink(dts.name)
+        try:
+            output = subprocess.check_output(
+                [sys.executable, '-m', 'fit_validate.validate', upl.name],
+                stderr=subprocess.STDOUT)
+            self.assertEqual(b'', output)
+        finally:
+            os.unlink(upl.name)
+
+    def test_require_fit_rejected_on_plain_fit(self):
+        """require-fit is a UPL extension, not part of the FIT spec"""
+        # Convert HEADER from UPL into plain FIT by swapping the UPL-only
+        # properties for their FIT counterparts and adding require-fit.
+        plain = HEADER.replace('project = "linux";', '')
+        plain = plain.replace('firmware = "image-1";',
+                              'kernel = "image-1";\n            '
+                              'require-fit;')
+        plain = plain.replace('config-1', 'conf-1')
+        # When run without -u and on a non-.upl file, require-fit is unknown.
+        with tempfile.NamedTemporaryFile(suffix='.dts', delete=False) as dts:
+            dts.write(plain.encode('utf-8'))
+            dts.close()
+            try:
+                output = subprocess.check_output(
+                    [sys.executable, '-m', 'fit_validate.validate', dts.name],
+                    stderr=subprocess.STDOUT)
+                self.fail('expected non-zero exit')
+            except subprocess.CalledProcessError as exc:
+                output = exc.output
+            finally:
+                os.unlink(dts.name)
+        self.assertIn(b"Unexpected property 'require-fit'", output)
+
     def test_extra(self):
         """Test complaining about extra nodes and properties"""
         result = self.run_test(HEADER + EXTRA)

--- a/fit_validate/validate_test.py
+++ b/fit_validate/validate_test.py
@@ -41,6 +41,8 @@ HEADER = '''/dts-v1/;
             data = "abc";
             os = "linux";
             project = "linux";
+            load = <0x10000000>;
+            entry = <0x10000000>;
         };
     };
 
@@ -68,6 +70,8 @@ SIGNED = '''/dts-v1/;
             data = "abc";
             os = "linux";
             project = "linux";
+            load = <0x10000000>;
+            entry = <0x10000000>;
             hash-1 {
                 algo = "sha256";
                 value = [00 11 22 33];
@@ -247,6 +251,48 @@ class UnitTests(unittest.TestCase):
             "missing",
             ], result)
 
+    def test_kernel_requires_os(self):
+        """type=kernel images must have an os property"""
+        bad = HEADER.replace('os = "linux";\n            ', '', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/images/image-1: Required property 'os' missing",
+            ], result)
+
+    def test_non_kernel_does_not_require_os(self):
+        """A non-kernel image without os should validate"""
+        ok = HEADER.replace('type = "kernel";', 'type = "ramdisk";', 1)
+        ok = ok.replace('os = "linux";\n            ', '', 1)
+        ok = ok.replace('load = <0x10000000>;\n            ', '', 1)
+        ok = ok.replace('entry = <0x10000000>;\n            ', '', 1)
+        self.assertEqual([], self.run_test(ok))
+
+    def test_invalid_arch(self):
+        """An arch outside the allowed set should be reported"""
+        bad = HEADER.replace('arch = "arm64";', 'arch = "z80";', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/images/image-1: 'arch' value 'z80' is not one of the allowed "
+            "values (invalid, alpha, arc, arm64, arm,",
+            ], result)
+
+    def test_invalid_compression(self):
+        """A compression outside the allowed set should be reported"""
+        bad = HEADER.replace(
+            'type = "kernel";',
+            'type = "kernel";\n            compression = "snappy";', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/images/image-1: 'compression' value 'snappy' is not one of "
+            "the allowed values (none, bzip2, gzip, lz4, lzma, lzo, zstd)",
+            ], result)
+
+    def test_root_description_optional(self):
+        """The spec says root description is optional"""
+        ok = HEADER.replace(
+            'description = "This is my description";\n    ', '', 1)
+        self.assertEqual([], self.run_test(ok))
+
     def test_default_references_missing_config(self):
         """`default` must name an existing configuration"""
         bad = HEADER.replace(
@@ -289,8 +335,7 @@ class UnitTests(unittest.TestCase):
             '''image-2 {
             description = "Chain target";
             arch = "arm64";
-            type = "kernel";
-            os = "linux";
+            type = "ramdisk";
             project = "linux";
             image-data = "image-1";
         };

--- a/fit_validate/validate_test.py
+++ b/fit_validate/validate_test.py
@@ -251,6 +251,73 @@ class UnitTests(unittest.TestCase):
             "missing",
             ], result)
 
+    def test_phase_value_invalid(self):
+        """The phase property must be 'spl' or 'u-boot'"""
+        bad = HEADER.replace(
+            'type = "kernel";',
+            'type = "kernel";\n            phase = "tpl";', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/images/image-1: 'phase' value 'tpl' is not one of the allowed "
+            "values (spl, u-boot)",
+            ], result)
+
+    def test_phase_value_ok(self):
+        """A correctly-spelled phase value should validate"""
+        ok = HEADER.replace(
+            'type = "kernel";',
+            'type = "kernel";\n            phase = "spl";', 1)
+        self.assertEqual([], self.run_test(ok))
+
+    def test_data_position_satisfies_data_requirement(self):
+        """An image with data-position should not require data-offset"""
+        ok = HEADER.replace(
+            'data = "abc";',
+            'data-position = <0x80000000>;\n            data-size = <0x100>;',
+            1)
+        self.assertEqual([], self.run_test(ok))
+
+    def test_fpga_requires_compatible(self):
+        """type=fpga requires the compatible property"""
+        bad = HEADER.replace('type = "kernel";', 'type = "fpga";', 1)
+        bad = bad.replace('os = "linux";\n            ', '', 1)
+        bad = bad.replace('load = <0x10000000>;\n            ', '', 1)
+        bad = bad.replace('entry = <0x10000000>;\n            ', '', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/images/image-1: Required property 'compatible' missing",
+            ], result)
+
+    def test_config_load_only(self):
+        """A config with load-only and no firmware should validate"""
+        ok = HEADER.replace(
+            'firmware = "image-1";',
+            'load-only;', 1)
+        # firmware is required for UPL configs, so the missing-firmware
+        # complaint still fires; only check that load-only itself is
+        # accepted as a known property.
+        result = self.run_test(ok)
+        for line in result:
+            self.assertNotIn('load-only', line)
+
+    def test_config_cmdline(self):
+        """A config with cmdline should validate"""
+        ok = HEADER.replace(
+            'firmware = "image-1";',
+            'firmware = "image-1";\n            cmdline = "console=ttyS0";', 1)
+        self.assertEqual([], self.run_test(ok))
+
+    def test_config_fpga_ref(self):
+        """A config's fpga property must reference an existing image"""
+        bad = HEADER.replace(
+            'firmware = "image-1";',
+            'firmware = "image-1";\n            fpga = "missing-fpga";', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/configurations/config-1: 'fpga' references missing node "
+            "'/images/missing-fpga'",
+            ], result)
+
     def test_kernel_requires_os(self):
         """type=kernel images must have an os property"""
         bad = HEADER.replace('os = "linux";\n            ', '', 1)

--- a/fit_validate/validate_test.py
+++ b/fit_validate/validate_test.py
@@ -247,6 +247,65 @@ class UnitTests(unittest.TestCase):
             "missing",
             ], result)
 
+    def test_default_references_missing_config(self):
+        """`default` must name an existing configuration"""
+        bad = HEADER.replace(
+            'configurations {',
+            'configurations {\n        default = "missing-conf";', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/configurations: 'default' references missing node "
+            "'/configurations/missing-conf'",
+            ], result)
+
+    def test_firmware_references_missing_image(self):
+        """A config's `firmware` must name an existing image"""
+        bad = HEADER.replace('firmware = "image-1"',
+                             'firmware = "ghost-image"', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/configurations/config-1: 'firmware' references missing node "
+            "'/images/ghost-image'",
+            ], result)
+
+    def test_loadables_references_missing_image(self):
+        """A config's `loadables` items must each name an existing image"""
+        bad = HEADER.replace(
+            'firmware = "image-1";',
+            'firmware = "image-1";\n            '
+            'loadables = "image-1", "missing-1", "missing-2";', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/configurations/config-1: 'loadables' references missing image "
+            "'missing-1'",
+            "/configurations/config-1: 'loadables' references missing image "
+            "'missing-2'",
+            ], result)
+
+    def test_image_data_no_chain(self):
+        """image-data target must not itself have image-data"""
+        chained = HEADER.replace(
+            'image-1 {',
+            '''image-2 {
+            description = "Chain target";
+            arch = "arm64";
+            type = "kernel";
+            os = "linux";
+            project = "linux";
+            image-data = "image-1";
+        };
+
+        image-1 {''', 1).replace(
+            'data = "abc";',
+            'image-data = "image-2";', 1)
+        result = self.run_test(chained)
+        self._check_all_in([
+            "/images/image-2: 'image-data' target 'image-1' itself has a "
+            "'image-data' property; chains are not permitted",
+            "/images/image-1: 'image-data' target 'image-2' itself has a "
+            "'image-data' property; chains are not permitted",
+            ], result)
+
     def test_whitespace_in_prop_name(self):
         """Test that trailing/leading whitespace in property names is reported
 

--- a/fit_validate/validate_test.py
+++ b/fit_validate/validate_test.py
@@ -53,6 +53,49 @@ HEADER = '''/dts-v1/;
 };
 '''
 
+# A header with hash and signature subnodes, signed with sha256+rsa2048.
+SIGNED = '''/dts-v1/;
+
+/ {
+    timestamp = <123456>;
+    description = "Signed image";
+    #address-cells = <1>;
+    images {
+        image-1 {
+            description = "Image description";
+            arch = "arm64";
+            type = "kernel";
+            data = "abc";
+            os = "linux";
+            project = "linux";
+            hash-1 {
+                algo = "sha256";
+                value = [00 11 22 33];
+            };
+            signature-1 {
+                algo = "sha256,rsa2048";
+                key-name-hint = "dev";
+                value = [aa bb cc dd];
+                hashed-nodes = "/", "/images/image-1";
+                hashed-strings = <0 0x100>;
+            };
+        };
+    };
+
+    configurations {
+        config-1 {
+            description = "Configuration description";
+            firmware = "image-1";
+            signature-1 {
+                algo = "sha256,rsa2048";
+                key-name-hint = "dev";
+                value = [aa bb cc dd];
+            };
+        };
+    };
+};
+'''
+
 EXTRA = '''
 / {
     wibble {
@@ -162,6 +205,47 @@ class UnitTests(unittest.TestCase):
             ["/images: Unexpected property 'extra-prop', valid list is ()",
              "/: Unexpected subnode 'wibble', valid list is (images, configurations)"],
              result)
+
+    def test_signed_ok(self):
+        """A FIT with valid hash and signature subnodes should validate"""
+        self.assertEqual([], self.run_test(SIGNED))
+
+    def test_hash_missing_algo(self):
+        """A hash node missing algo should be reported"""
+        bad = SIGNED.replace('                algo = "sha256";\n', '', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/images/image-1/hash-1: Required property 'algo' missing",
+            ], result)
+
+    def test_hash_unknown_algo(self):
+        """An unsupported hash algorithm should be reported"""
+        bad = SIGNED.replace('algo = "sha256";', 'algo = "blake3";', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/images/image-1/hash-1: 'algo' value 'blake3' does not match "
+            "pattern '^crc16-ccitt|crc32|md5|sha1|sha256|sha384|sha512$'",
+            ], result)
+
+    def test_signature_unknown_algo(self):
+        """An unsupported signature algorithm should be reported"""
+        bad = SIGNED.replace('"sha256,rsa2048"', '"sha256,dilithium3"', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/images/image-1/signature-1: 'algo' value 'sha256,dilithium3' "
+            "does not match pattern "
+            "'^(sha1|sha256|sha384|sha512),(rsa\\d+|ecdsa\\d+)$'",
+            ], result)
+
+    def test_image_signature_missing_required(self):
+        """An image signature missing hashed-nodes should be reported"""
+        bad = SIGNED.replace(
+            'hashed-nodes = "/", "/images/image-1";\n            ', '', 1)
+        result = self.run_test(bad)
+        self._check_all_in([
+            "/images/image-1/signature-1: Required property 'hashed-nodes' "
+            "missing",
+            ], result)
 
     def test_whitespace_in_prop_name(self):
         """Test that trailing/leading whitespace in property names is reported

--- a/fit_validate/validate_test.py
+++ b/fit_validate/validate_test.py
@@ -141,7 +141,8 @@ class UnitTests(unittest.TestCase):
             dts.close()
             self.returncode = 0
             if use_command_line:
-                call_args = ['python', '-m', 'fit_validate.validate', dts.name]
+                call_args = [sys.executable, '-m', 'fit_validate.validate',
+                             dts.name]
                 if extra_options:
                     call_args += extra_options
                 try:
@@ -198,7 +199,7 @@ class UnitTests(unittest.TestCase):
                 "/configurations/config-1: Required property 'firmware' missing",
                 ], result)
 
-    def test_comannd_line(self):
+    def test_command_line(self):
         """Test that the command-line interface works correctly"""
         self.assertEqual([], self.run_test(HEADER, True, ['-u']))
 

--- a/fit_validate/validate_test.py
+++ b/fit_validate/validate_test.py
@@ -12,6 +12,9 @@ import sys
 import tempfile
 import unittest
 
+# pylint: disable=E0401
+import libfdt
+
 if __name__ == "__main__":
     # Allow 'from validate import xxx to work'
     our_path = os.path.dirname(os.path.realpath(__file__))
@@ -159,6 +162,38 @@ class UnitTests(unittest.TestCase):
             ["/images: Unexpected property 'extra-prop', valid list is ()",
              "/: Unexpected subnode 'wibble', valid list is (images, configurations)"],
              result)
+
+    def test_whitespace_in_prop_name(self):
+        """Test that trailing/leading whitespace in property names is reported
+
+        Some FIT producers emit property names with stray whitespace (for
+        example by splitting a DTS-like ``name  = "value"`` line on ``=``
+        without strip()-ing the LHS). A binary FIT carries those names
+        verbatim, so the validator should flag the malformed name rather than
+        report a generic 'Unexpected property' error.
+        """
+        fdt = libfdt.Fdt.create_empty_tree(1024)
+        fdt.setprop_u32(0, '#address-cells', 1)
+        fdt.setprop_u32(0, 'timestamp', 123456)
+        fdt.setprop_str(0, 'description', 'desc')
+        fdt.setprop_u32(0, 'description ', 0)  # trailing space, matches schema
+        fdt.setprop_str(0, 'oddprop ', 'x')    # trailing space, no schema match
+        with tempfile.NamedTemporaryFile(suffix='.fit', delete=False) as fit:
+            fit.write(bytes(fdt.as_bytearray()))
+            fit.close()
+            tools.prepare_output_dir(None)
+            errors = self.val.start(fit.name)
+            tools.finalise_output_dir()
+            os.unlink(fit.name)
+        self.assertIn(
+            "/: Property name 'description ' has surrounding whitespace; "
+            "check the tool that produced this FIT (did you mean "
+            "'description'?)",
+            errors)
+        self.assertIn(
+            "/: Property name 'oddprop ' has surrounding whitespace; "
+            "check the tool that produced this FIT",
+            errors)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

A Python-based validator for Flat Image Tree (FIT) files. The validator
walks a binary FIT (or compiles a `.dts` source on the fly) and reports
errors against a schema derived from `chapter5-source-file-format.rst`.

It selects the schema per file: `.upl`-suffixed files are checked
against the Universal Payload (UPL) variant; everything else uses the
plain FIT schema. The `-u` flag forces UPL globally for callers that
prefer it.

## What is checked

- **Property structure on `/`, `/images/<image>` and `/configurations/<config>`** —
  required and optional properties per the spec, including
  type-conditional requirements (`os` only for `type=kernel`; `arch`
  for standalone/kernel/firmware/ramdisk/fdt; `entry`/`load` for
  firmware/kernel; `compatible` mandatory on fpga images).
- **Closed value sets** — `type`, `arch`, `os`, `compression` and
  `phase` are checked against the spec's enumerations.
- **Hash subnodes** (`hash-N`) — `algo` (crc16-ccitt | crc32 | md5 |
  sha1 | sha256 | sha384 | sha512) and `value` are required.
- **Signature subnodes** (`signature-N`) — composite `algo`
  (`<hash>,<rsa|ecdsa>NNNN`), `key-name-hint`, `value` plus the
  signing-time metadata (hashed-nodes, hashed-strings, signer-name,
  padding pkcs-1.5 / pss, etc.) per the image- and configuration-
  signature sections of the spec.
- **Cross-references** — `default` in `/configurations` must name an
  existing configuration; `firmware`, `kernel`, `fdt`, `ramdisk`,
  `fpga`, `script` and each item of `loadables` and `sign-images` must
  name an existing image; `image-data` must name an existing image
  *and* the target must not itself have `image-data` (no chains).
- **Producer-side mistakes** — property names with leading or trailing
  whitespace are flagged with a specific diagnostic and a "did you
  mean" hint, instead of being buried under a generic
  *Unexpected property* error.

## Commits

```
Add a .gitignore file
Add an initial validator for FIT
fit_validate: Detect surrounding whitespace in property names
fit_validate: Validate hash and signature subnodes
fit_validate: Validate cross-references between configs and images
fit_validate: Tighten image property requirements per the spec
fit_validate: Cover the remaining image and config properties
fit_validate: Fix command-line test on Python-3-only systems
fit_validate: Make require-fit UPL-only, auto-detect .upl files
```

## Tests

```
python3 -m fit_validate.validate_test
```

28 unit tests pass. Fixtures cover the happy path plus the most useful
failure modes (missing required props, type-driven requirement gating,
unknown enum values, broken cross-references, malformed property names
and the no-chain rule for `image-data`). Hash- and signature-related
tests are built directly with `libfdt` so they exercise the binary
form rather than going through `dtc`.

## Known gaps

Still on the audit list, deferred for follow-up:

- `dm-verity` subnodes (chapter 5, lines 555-644) under
  `filesystem`-typed images, with seven mandatory properties and
  the size/power-of-2 constraints.
- Tighter value enumeration on the image-level `compatible` property
  (the spec only enumerates the fpga loading methods explicitly, so
  for now the value list is left open).

## Test plan

- [ ] Run `python3 -m fit_validate.validate_test` and confirm 28
      tests pass.
- [ ] Run the validator against a real FIT or UPL file from your
      build and confirm the output is sensible.
- [ ] Validate a UPL FIT by giving it a `.upl` suffix; confirm
      `project`, `firmware` and `require-fit` are recognised
      without passing `-u`.