### PR TITLE
Add note for fdt image to not derive compatible from fdt or model

### DIFF
--- a/source/chapter2-source-file-format.rst
+++ b/source/chapter2-source-file-format.rst
@@ -355,6 +355,10 @@ compatible
                                 UltraScale+ (ZynqMP) device.
     ==========================  =========================================
 
+    *Note* For fdt images, the node should not have a compatible for the model.
+    The compatible here is not derived from the fdt, nor is it used to identify
+    the fdt. Such usage belongs in the configuration node.
+
 phase
     U-Boot phase for which the image is intended.
 


### PR DESCRIPTION
While the image section already mentions that the compatible refers to a method of loading the image to memory, users could miss it and derive the compatible for fdt images from the fdt compatible or the model.

Add an explicit note stating otherwise.