### PR TITLE
Correct warning about html_static_path

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -126,7 +126,7 @@ html_favicon = "fit-favicon.png"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
Fix this warning by commenting out the line:

WARNING: html_static_path entry '_static' does not exist

There may be static files added later. For now there is none.