### PR TITLE
Point source at release

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,4 +143,8 @@ By making a contribution to this project, I certify that:
     this project or the open source license(s) involved.
 ```
 
+## Automatic publication
+
+This document is automatically published to the Open Source Firmware Foundation website at https://fitspec.osfw.foundation/. 
+
 <!-- SPDX-License-Identifier: Apache-2.0 -->


### PR DESCRIPTION
It looks like there is a link from published document back to the source, but it might be nice to have a forward link. I can see it being a maintenance problem too. Just a thought.