### PR TITLE
Add ELF Images to OS formats list

### DIFF
--- a/source/chapter2-source-file-format.rst
+++ b/source/chapter2-source-file-format.rst
@@ -280,6 +280,7 @@ os
     arm-trusted-firmware  ARM Trusted Firmware
     dell                  Dell
     efi                   EFI Firmware
+    elf                   ELF Image
     esix                  Esix
     freebsd               FreeBSD
     integrity             INTEGRITY


### PR DESCRIPTION
The ability to run these images was added to U-Boot recently and did not make it into the migration from the project source tree. Original patch:
https://lore.kernel.org/all/20240715200110.34230-1-Maxim.Moskalets@kaspersky.com/