### PR TITLE
chapter2: add optional commandline property to configuration

### DIFF
--- a/source/chapter2-source-file-format.rst
+++ b/source/chapter2-source-file-format.rst
@@ -560,6 +560,7 @@ Each configuration has the following structure::
     o config-1
         |- description = "configuration description";
         |- kernel = "kernel sub-node unit name";
+        |- cmdline = "command line for next boot stage";
         |- fdt = "fdt sub-node unit-name" [, "fdt overlay sub-node unit-name", ...];
         |- ramdisk = "ramdisk sub-node unit-name";
         |- loadables = "loadables sub-node unit-name" [, ...];
@@ -580,6 +581,10 @@ kernel or firmware
 
 Optional properties
 ~~~~~~~~~~~~~~~~~~~
+
+cmdline
+    Command line passed to the next boot stage, e.g. the operating system
+    kernel. The value is an UTF-8 encoded string.
 
 fdt
     Unit name of the corresponding fdt blob (component image node of a


### PR DESCRIPTION
The Linux kernel needs a command line to indicate the root file system. Further parameters may be passed on the command line [1].

Add an optional commandline property to configuration nodes.

The UEFI specification uses UCS-2 encoded strings. UCS-2 is a deprecated encoding of the Unicode Basic Multilingual Plane. Using UTF-8 for encoding the commandline property allows to represent all UCS-2 characters when passing the string to an EFI binary via the EFI Loaded Image Protocol as a load option.

[1] The kernel’s command-line parameters
    https://www.kernel.org/doc/html/v4.14/admin-guide/kernel-parameters.html