### PR TITLE
add dm-verity subnode for filesystem images

### DIFF
--- a/source/chapter5-source-file-format.rst
+++ b/source/chapter5-source-file-format.rst
@@ -167,6 +167,7 @@ the '/images' node should have the following layout::
         |
         o hash-1 {...}
         o hash-2 {...}
+        o dm-verity {...}
         ...
 
 Mandatory properties
@@ -393,6 +394,12 @@ signature-1
     Each signature sub-node represents a separate signature
     calculated for node's data according to specified algorithm.
 
+dm-verity
+    For images of type ``filesystem``, this sub-node carries dm-verity
+    Merkle-tree metadata so that the bootloader can construct kernel
+    command-line parameters for integrity-verified boot.
+    See `dm-verity nodes`_.
+
 .. index:: Hash nodes
 
 Hash nodes
@@ -516,6 +523,110 @@ padding
     The padding algorithm, it may be pkcs-1.5 or pss,
     if no value is provided we assume pkcs-1.5
 
+
+.. index:: dm-verity nodes
+
+.. _dm-verity-nodes:
+
+dm-verity nodes
+---------------
+
+Image nodes whose type is ``filesystem`` may contain an optional ``dm-verity``
+child node. The bootloader uses this metadata to construct ``dm-mod.create``
+and ``dm-mod.waitfor`` kernel command-line parameters so that the kernel can set
+up a `dm-verity
+<https://docs.kernel.org/admin-guide/device-mapper/verity.html>`_ integrity
+target over the corresponding block device at boot.
+
+See :ref:`verity-usage` for details on how a bootloader should translate these
+properties into kernel command-line parameters.
+
+::
+
+    o dm-verity
+        |- data-block-size = <data block size in bytes>
+        |- hash-block-size = <hash block size in bytes>
+        |- num-data-blocks = <number of data blocks>
+        |- hash-start-block = <hash tree start block>
+        |- algo = "hash algorithm name"
+        |- digest = [root hash bytes]
+        |- salt = [salt bytes]
+
+The property names are intentionally aligned with the `dm-verity construction
+parameters <https://docs.kernel.org/admin-guide/device-mapper/verity.html>`_
+defined by the Linux kernel. The ``<version>`` parameter is always ``1``, and
+``<dev>`` / ``<hash_dev>`` both implicitly refer to the ``/dev/fitN`` block
+device that the Linux uImage.FIT block driver creates for this sub-image.
+
+Mandatory properties
+~~~~~~~~~~~~~~~~~~~~
+
+data-block-size
+    The block size on the data device in bytes. Each block corresponds to one
+    digest in the hash tree. Must be a power of two and at least 512;
+    typically 4096.
+
+hash-block-size
+    The size of a hash block in bytes. Must be a power of two and at least 512;
+    typically 4096.
+
+num-data-blocks
+    The number of data blocks on the data device. This corresponds to the
+    ``<num_data_blocks>`` dm-verity parameter and the value reported by
+    ``veritysetup format``.
+
+hash-start-block
+    Offset in ``hash-block-size``-sized blocks from the start of the sub-image
+    to the root block of the hash tree. Corresponds to the
+    ``<hash_start_block>`` dm-verity parameter.
+
+algo
+    The cryptographic hash algorithm used for dm-verity, e.g. ``"sha256"``.
+
+digest
+    The root hash of the dm-verity Merkle tree, stored as a raw byte array.
+    The length must match the output size of ``algo``.
+
+salt
+    Salt value, stored as a raw byte array.
+
+Optional properties
+~~~~~~~~~~~~~~~~~~~
+
+restart-on-corruption
+    Boolean. Restart the system when a corrupted block is discovered.
+    Corresponds to ``restart_on_corruption``.
+
+panic-on-corruption
+    Boolean. Panic the system when a corrupted block is discovered. Not
+    compatible with ``restart-on-corruption``. Corresponds to
+    ``panic_on_corruption``.
+
+restart-on-error
+    Boolean. Restart the system when an I/O error is detected. Corresponds to
+    ``restart_on_error``.
+
+panic-on-error
+    Boolean. Panic the system when an I/O error is detected. Not compatible
+    with ``restart-on-error``. Corresponds to ``panic_on_error``.
+
+check-at-most-once
+    Boolean. Verify data blocks only the first time they are read, reducing
+    overhead on constrained systems at the cost of not detecting online
+    tampering. Corresponds to ``check_at_most_once``.
+
+When none of the error-handling properties are present, the kernel default
+behaviour (return I/O error) applies.
+
+Additional optional parameters defined by the kernel's `dm-verity target
+<https://docs.kernel.org/admin-guide/device-mapper/verity.html>`_ may be added
+as properties in future revisions of this specification.
+
+These values correspond to the parameters passed to ``dm-mod.create`` on the
+kernel command line (see :ref:`verity-usage`).
+
+Both the filesystem payload data and the dm-verity Merkle-tree hash data are
+expected to reside inside the same sub-image.
 
 '/configurations' node
 ----------------------

--- a/source/chapter6-usage.rst
+++ b/source/chapter6-usage.rst
@@ -234,4 +234,150 @@ no                   yes                 Execute binary
 yes                  yes                 Execute binary
 ===================  ==================  ====================
 
+.. _verity-usage:
+
+dm-verity for filesystem images
+-------------------------------
+
+A FIT may contain ``filesystem``-type sub-images that carry a ``dm-verity``
+child node (see :ref:`dm-verity-nodes`). Such images bundle both the
+filesystem payload and the dm-verity Merkle-tree hash data inside the same
+sub-image. A Linux block driver exposes each loadable sub-image as
+``/dev/fit0``, ``/dev/fit1``, etc.
+
+When a ``dm-verity`` node is present, the bootloader should translate its
+properties into kernel command-line parameters so that the kernel can activate
+a dm-verity integrity target at boot, before mounting the root filesystem.
+Two parameters are needed:
+
+``dm-mod.waitfor``
+    Tells ``dm-init`` to wait for the block device to appear before creating
+    mapped devices. The bootloader should list the ``/dev/fitN`` device that
+    corresponds to the sub-image::
+
+        dm-mod.waitfor=/dev/fit0
+
+``dm-mod.create``
+    Defines a device-mapper table using the ``--concise`` format accepted by
+    ``dmsetup``. The general form for a verity target is::
+
+        <name>,<uuid>,<minor>,ro,
+          0 <num_sectors> verity <version>
+          <dev> <hash_dev>
+          <data_block_size> <hash_block_size>
+          <num_data_blocks> <hash_start_block>
+          <algorithm> <digest> <salt>
+          [<#opt_params> <opt_params>]
+
+    Because both the filesystem data and the hash tree reside inside the same
+    ``/dev/fitN`` device, ``<dev>`` and ``<hash_dev>`` are identical and shall
+    be set by the bootloader. The ``<version>`` is always ``1``.
+
+Field mapping
+~~~~~~~~~~~~~
+
+The following table shows how each dm-verity construction parameter
+is derived from the ``dm-verity`` node properties.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - dm-verity parameter
+     - Source
+   * - ``<name>``
+     - The unit name of the ``/images`` sub-node that contains the
+       ``dm-verity`` child node.
+   * - ``<uuid>``
+     - May be left empty (``""``).
+   * - ``<minor>``
+     - May be left empty (``""``).
+   * - ``<num_sectors>``
+     - ``num-data-blocks * (data-block-size / 512)``
+   * - ``<version>``
+     - Always ``1``.
+   * - ``<dev>``, ``<hash_dev>``
+     - Both set to the ``/dev/fitN`` block device that the uImage.FIT block
+       driver creates for this sub-image.
+   * - ``<data_block_size>``
+     - ``data-block-size`` from the ``dm-verity`` node.
+   * - ``<hash_block_size>``
+     - ``hash-block-size`` from the ``dm-verity`` node.
+   * - ``<num_data_blocks>``
+     - ``num-data-blocks`` from the ``dm-verity`` node.
+   * - ``<hash_start_block>``
+     - ``hash-start-block`` from the ``dm-verity`` node.
+   * - ``<algorithm>``
+     - ``algo`` from the ``dm-verity`` node.
+   * - ``<digest>``
+     - ``digest`` from the ``dm-verity`` node, hex-encoded.
+   * - ``<salt>``
+     - ``salt`` from the ``dm-verity`` node, hex-encoded.
+   * - ``<opt_params>``
+     - Constructed from the boolean option properties present in the
+       ``dm-verity`` node (e.g. ``restart-on-corruption``,
+       ``panic-on-error``). The bootloader collects every option property that
+       is present, converts the property name from hyphenated to underscored
+       form (e.g. ``restart-on-corruption`` becomes ``restart_on_corruption``),
+       counts them, and appends ``<count> <option> [<option> ...]`` to the
+       target line.
+
+Example
+~~~~~~~
+
+Given a ``filesystem`` sub-image node named ``rootfs-1``,
+exposed as ``/dev/fit0``, whose ``dm-verity`` node contains::
+
+    dm-verity {
+        data-block-size = <4096>;
+        hash-block-size = <4096>;
+        num-data-blocks = <204800>;
+        hash-start-block = <204800>;
+        algo = "sha256";
+        digest = [ac 87 db 56 30 3c 9c 1d a4 33 d7 20 9b 5a 6e f3
+                  e4 77 9d f1 41 20 0c bd 7c 15 7d cb 8d d8 9c 42];
+        salt = [5e bf e8 7f 7d f3 23 5b 80 a1 17 eb c4 07 8e 44
+                f5 50 45 48 7a d4 a9 65 81 d1 ad b5 64 61 5b 51];
+        panic-on-corruption;
+        panic-on-error;
+    };
+
+The bootloader constructs::
+
+    dm-mod.waitfor=/dev/fit0
+
+    dm-mod.create="rootfs-1,,, ro,
+      0 1638400 verity 1
+      /dev/fit0 /dev/fit0
+      4096 4096 204800 204800 sha256
+      ac87db56303c9c1da433d7209b5a6ef3e4779df141200cbd7c157dcb8dd89c42
+      5ebfe87f7df3235b80a117ebc4078e44f55045487ad4a96581d1adb564615b51
+      2 panic_on_corruption panic_on_error"
+
+.. note::
+
+   The newlines inside the ``dm-mod.create`` value above are
+   for readability only. The actual kernel command-line
+   parameter must be a single line.
+
+Here ``num_sectors`` = 204800 × (4096 / 512) = 1638400. ``<name>`` is the image
+unit name ``rootfs-1``; ``<uuid>`` and ``<minor>`` are left empty; ``ro``
+indicates a read-only target. ``<dev>`` and ``<hash_dev>`` are both
+``/dev/fit0`` because the filesystem data and the Merkle tree reside in the same
+sub-image. The two boolean properties ``panic-on-corruption`` and
+``panic-on-error`` become the optional-parameter suffix ``2 panic_on_corruption
+panic_on_error`` (count followed by underscore-separated names). The remaining
+fields map directly from the ``dm-verity`` node properties.
+
+.. note::
+
+   When preparing the sub-image with ``veritysetup format``, pass
+   ``--no-superblock`` so that the hash tree starts directly after
+   the data blocks. By default ``veritysetup`` writes a one-block
+   on-disk superblock between data and hash tree, which would shift
+   ``hash-start-block`` to ``num-data-blocks + 1``. The kernel
+   dm-verity target never reads this superblock — all parameters
+   are supplied via ``dm-mod.create`` — so it is unnecessary when
+   the metadata is already stored in the FIT ``dm-verity`` node.
+
 .. sectionauthor:: Simon Glass <sjg@chromium.org>

--- a/source/chapter7-security.rst
+++ b/source/chapter7-security.rst
@@ -14,9 +14,11 @@ refers to. The bootloader must check the signatures against a public key which
 it has stored elsewhere.
 
 If any configuration fails its signature check, then it must be ignored. Images
-must each include a suitable hash node, so that images are actually protected
-against modification. Once each image is loaded, its hash must be computed and
-checked against the hash in the FIT.
+must each include a suitable hash node so that they are protected against
+modification. Once each image is loaded, its hash must be computed and checked
+against the hash in the FIT. The exception is ``filesystem``-type images that
+carry a ``dm-verity`` node: their integrity is delegated to the kernel's
+dm-verity target rather than verified by the bootloader.
 
 For more information on FIT security, see
 `U-Boot's documentation <https://docs.u-boot.org/en/latest/usage/fit/signature.html>`_.
@@ -48,7 +50,8 @@ configuration signature covers:
 
 - the configuration node itself (including its references to images),
 - each image node referenced by the configuration,
-- the hash sub-nodes of those images, and
+- the hash sub-nodes of those images,
+- the ``dm-verity`` sub-nodes of those images (where present), and
 - the root (``/``) node of the FIT.
 
 Because the signature covers the hash sub-nodes, the image data is
@@ -88,12 +91,20 @@ The bootloader verifies a configuration as follows:
 #. The signature covers certain FDT nodes and a region of the string table
    (see :ref:`hash_contents` below). Rebuild the list of nodes that should
    have been signed (the root node, the configuration node, each referenced
-   image node and its hash sub-nodes) and verify that the hash of those nodes
+   image node, its hash sub-nodes, and any ``dm-verity`` sub-node) and verify
+   that the hash of those nodes
    matches the signature.
 #. For each image referenced by the configuration, compute the hash of the
    image data and compare it against the ``value`` in the image's hash
    sub-node. This step may be deferred until the image is actually loaded,
    which can be some time after the configuration is selected.
+
+   For ``filesystem``-type images that carry a ``dm-verity`` child node and
+   are being used to launch Linux, the bootloader *may* omit loading the
+   image into RAM and skip this hash check entirely. Instead, the bootloader
+   shall derive kernel command-line parameters from the ``dm-verity`` node as
+   described in :ref:`verity-usage`, delegating integrity verification to the
+   kernel's dm-verity target at mount time.
 
 If any step fails, the configuration must be rejected.
 
@@ -122,8 +133,10 @@ contains:
 - each image node referenced by the configuration
   (e.g. ``/images/kernel``, ``/images/fdt-1``),
 - the hash sub-nodes of those image nodes
-  (e.g. ``/images/kernel/hash-1``, ``/images/fdt-1/hash-1``), and
-- any cipher sub-nodes of those image nodes (e.g. ``/images/kernel/cipher-1``).
+  (e.g. ``/images/kernel/hash-1``, ``/images/fdt-1/hash-1``),
+- any cipher sub-nodes of those image nodes (e.g. ``/images/kernel/cipher-1``), and
+- the ``dm-verity`` sub-node of any ``filesystem``-type image node that carries one
+  (e.g. ``/images/rootfs-1/dm-verity``).
 
 The signer walks the FDT structure block sequentially and includes or excludes
 each token according to the following rules:


### PR DESCRIPTION
Image nodes of type "filesystem" may carry an optional dm-verity child node containing Merkle-tree metadata (algo, block-size, data-blocks, root-hash, salt).  A bootloader uses these properties to construct `dm-mod.create=` and `dm-mod.waitfor=` kernel command-line parameters so that the kernel can set up a dm-verity integrity target over the corresponding block device at boot time.

This is used by U-Boot's CONFIG_FIT_VERITY feature together with the Linux uImage.FIT block driver which exposes FIT loadable sub-images as `/dev/fitN` block devices.