### PR TITLE
Add install-uuid optional root-node property

### DIFF
--- a/source/chapter2-source-file-format.rst
+++ b/source/chapter2-source-file-format.rst
@@ -101,6 +101,7 @@ The root node of the FIT should have the following layout::
         |- description = "image description"
         |- timestamp = <12399321>
         |- #address-cells = <1>
+        |- install-uuid = [4e 30 74 52 65 41 4c 4c 92 72 61 6e 64 30 6d 21]
         |
         o images
         | |
@@ -115,11 +116,19 @@ The root node of the FIT should have the following layout::
           o conf-2 {...}
           ...
 
-Optional property
-~~~~~~~~~~~~~~~~~
+Optional properties
+~~~~~~~~~~~~~~~~~~~
 
 description
     Textual description of the FIT
+
+install-uuid
+    A 16-byte UUID (:RFC:`4122`) that uniquely identifies a particular
+    installation of this FIT image. Tooling should generate a fresh UUID each
+    time the image is written to persistent storage. UUIDv4 (random) is
+    recommended for systems that lack a reliable time source; UUIDv1
+    (time-based) may be used when an RTC or NTP-synchronized clock is
+    available.
 
 Mandatory property
 ~~~~~~~~~~~~~~~~~~

--- a/source/chapter3-usage.rst
+++ b/source/chapter3-usage.rst
@@ -163,6 +163,19 @@ in use.
 The fixups required depend on the OS and its expectations. The result is a
 devicetree slightly modified from the FIT version.
 
+When the root node of the FIT contains an ``install-uuid`` property, the
+bootloader should copy it into the OS devicetree as
+``/chosen/u-boot,fit-install-uuid``. This lets the running operating system
+determine which installed image - and which location on storage - it was
+booted from, which is particularly valuable for system-update agents that need
+to identify the active image before writing a new one.
+
+An all-zero ``install-uuid`` (16 bytes of ``0x00``) may be used as a
+placeholder at build time. Tooling that writes the FIT to persistent storage
+must replace an all-zero value with a freshly generated random UUID before the
+image is considered installed. Bootloaders should treat an all-zero
+``install-uuid`` as absent and not propagate it to the OS devicetree.
+
 Jump to the OS
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add an optional `install-uuid` property to the FIT root node. It holds a 16-byte UUIDv4 (RFC 4122) that uniquely identifies a particular installation of a FIT image. Tooling should generate a fresh UUID each time the image is written to persistent storage. The bootloader should pass the UUID down to the OS as `/chosen/u-boot,fit-install-uuid` in FDT.