### PR TITLE
chapter2: Clarify that hashed-nodes is only a signer hint

### DIFF
--- a/source/chapter2-source-file-format.rst
+++ b/source/chapter2-source-file-format.rst
@@ -471,7 +471,7 @@ key-name-hint
     <name>.crt.
 
 sign-images
-    A list of images to sign, each being a property of the conf
+    An unsorted list of images to sign, each being a property of the conf
     node that contains them. The default is "kernel,fdt" which means that these
     two images will be looked up in the config and signed if present. This is
     used by mkimage to determine which images to sign.
@@ -482,8 +482,11 @@ value
     Actual signature value. This is added by mkimage.
 
 hashed-nodes
-    A list of nodes which were :index:`hashed <pair: nodes; hashed>` by the
-    signer. Each is a string - the full path to node. A typical value might be::
+    An unsorted list of nodes which were :index:`hashed <pair: nodes; hashed>`
+    by the signer. Each is a string - the full path to node. Since this
+    property is not itself protected by a hash, it serves only as a hint for
+    the signer and must not be relied upon by the loader for validation
+    purposes. A typical value might be::
 
 	hashed-nodes = "/", "/configurations/conf-1", "/images/kernel",
 	    "/images/kernel/hash-1", "/images/fdt-1",


### PR DESCRIPTION
The hashed-nodes property is not itself protected by a hash, so
a loader cannot rely on it for validation. Clarify that it serves
only as a hint for the signer.
