### PR TITLE
Bump specification version to 1.0

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,0 +1,35 @@
+name: Tag on merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Extract version from label
+      id: version
+      env:
+        LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+      run: |
+        # Find the label matching release-*, e.g. release-v1.0
+        LABEL=$(echo "$LABELS_JSON" \
+          | jq -r '.[] | select(startswith("release-"))' | head -1)
+        TAG="${LABEL#release-}"
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+    - name: Create tag
+      if: steps.version.outputs.tag != ''
+      env:
+        TAG: ${{ steps.version.outputs.tag }}
+        SHA: ${{ github.sha }}
+      run: |
+        git tag "$TAG" "$SHA"
+        git push origin "$TAG"

--- a/source/conf.py
+++ b/source/conf.py
@@ -31,9 +31,14 @@ author = u'Marian Balakowicz <m8@semihalf.com>'
 
 # The short X.Y version
 try:
-    version = str(subprocess.check_output(["git", "describe", "--dirty"]), 'utf-8').strip()
+    version = str(subprocess.check_output(
+        ["git", "describe", "--exact-match"]), 'utf-8').strip()
 except:
-    version = "unknown-rev"
+    try:
+        version = str(subprocess.check_output(
+            ["git", "describe", "--dirty"]), 'utf-8').strip()
+    except:
+        version = "unknown-rev"
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/source/revhistory.rst
+++ b/source/revhistory.rst
@@ -7,9 +7,14 @@ Revision History
 .. tabularcolumns:: | p{1.5cm} p{2.25cm} p{11.50cm} |
 .. table:: Revision History
 
-   ========= =========== ====================================================
-   Revision  Date        Description
-   ========= =========== ====================================================
-   0.8       2023-AUG-9  Initial prerelease version. Imported text from U-Boot
-                         source tree.
-   ========= =========== ====================================================
+   ========= ============ ===================================================
+   Revision  Date         Description
+   ========= ============ ===================================================
+   0.8       2023-AUG-9   Initial prerelease version. Imported text from
+                          U-Boot source tree.
+   1.0       2026-APR-11  First release. Add security architecture and hash
+                          contents documentation, dm-verity support for
+                          filesystem images, shared image data via
+                          image-data property, multi-step loading and
+                          configuration cmdline property.
+   ========= ============ ===================================================

--- a/source/rst_prolog
+++ b/source/rst_prolog
@@ -2,8 +2,8 @@
 
 .. Revision of the specification
 
-.. |fitspec-major| replace:: 0
-.. |fitspec-minor| replace:: 8
+.. |fitspec-major| replace:: 1
+.. |fitspec-minor| replace:: 0
 
 .. General Macros
 


### PR DESCRIPTION
Mark the specification as version 1.0, since there are some more major
changes in the works.

Update conf.py to prefer an exact tag match for the version string,
falling back to git-describe for untagged builds.

Add a tag-on-merge workflow that creates a git tag when a PR with
`release` and `release-v*` labels is merged, triggering the existing
release job in CI.