### PR TITLE
Correct a few typos in the algo table

### DIFF
--- a/source/chapter5-source-file-format.rst
+++ b/source/chapter5-source-file-format.rst
@@ -462,8 +462,8 @@ algo
     ==================== ============ =========================================
     sha1,rsa2048         256          SHA1 hash signed with 2048-bit
                                       Rivest–Shamir–Adleman algorithm
-    sha1,rsa3072         384          SHA1 hash signed with 2048-bit RSA
-    sha1,rsa4096         512          SHA1 hash signed with 2048-bit RSA
+    sha1,rsa3072         384          SHA1 hash signed with 3072-bit RSA
+    sha1,rsa4096         512          SHA1 hash signed with 4096-bit RSA
     sha1,ecdsa256        32           SHA1 hash signed with 256-bit  Elliptic
                                       Curve Digital Signature Algorithm
     sha256,...


### PR DESCRIPTION
The bit lengths don't match the sub-image type in a few cases. Fix them.

Suggested by Github user EdenBT2024:

   https://github.com/u-boot/u-boot/pull/612