### PR TITLE
Define constrained-FDT trailer and whole-FIT signing

### DIFF
--- a/source/chapter7-security.rst
+++ b/source/chapter7-security.rst
@@ -444,4 +444,195 @@ The complete byte sequence (structure-block regions plus strings-block region)
 is hashed with SHA-256. The resulting digest is then signed with the RSA-2048
 private key to produce the signature ``value``.
 
+
+Whole-FIT signing
+-----------------
+
+Per-configuration signing covers the integrity of one configuration and
+the images it references. A FIT may additionally carry a *whole-FIT
+signature* over the entire FIT image, including the FDT and any
+external image data. Whole-FIT signing is intended to complement
+per-configuration signing, not to replace it.
+
+A whole-FIT signature is stored in the binary trailer (see
+:ref:`chapter-binary-trailer`) as a ``signature-N`` property. The
+trailer is a constrained FDT blob placed inside the main FDT but
+excluded from the signed range, so its contents (including the
+signatures themselves) can be modified post-signing.
+
+Why whole-FIT signing
+~~~~~~~~~~~~~~~~~~~~~
+
+Per-configuration signing requires the bootloader to parse the FIT's
+FDT before authentication: it must locate the configuration node, the
+referenced image nodes, and the signature node, then construct the
+node list and hash the relevant FDT structure bytes. The pre-auth
+parser is therefore a full FDT parser (e.g. libfdt), which is large
+and has historically been a source of bugs when fed adversarial
+input.
+
+Whole-FIT signing allows a bootloader to authenticate the FIT before
+parsing any FDT structure. The verifier reads a small number of
+fixed-offset fields, hashes a contiguous byte range, and checks the
+signature. Only after the signature verifies does the bootloader
+parse the FDT — and at that point it is operating on trusted bytes.
+
+Bootloaders that need a smaller pre-authentication attack surface
+should use whole-FIT signing. Bootloaders that already trust the FDT
+parser they use may continue to use per-configuration signing alone.
+A FIT may carry both, so a single image can serve both kinds of
+bootloader.
+
+What is signed
+~~~~~~~~~~~~~~
+
+A whole-FIT signature covers two byte ranges, in this order:
+
+#. ``[0, 0x28)`` — the main FDT header (40 bytes). The trailer's fixed
+   ``totalsize`` keeps every header field stable, so the entire header
+   is signed without exclusions. This authenticates the FDT's
+   internal layout (``totalsize``, ``off_dt_struct``, ``off_dt_strings``,
+   ``off_mem_rsvmap``) as well as the external data extent
+   (``boot_cpuid_phys``).
+#. ``[0x28 + trailer_totalsize, totalsize + boot_cpuid_phys)`` —
+   the main FDT's memreserve, structure and strings blocks, followed
+   by all external image data.
+
+The trailer itself, ``[0x28, 0x28 + trailer_totalsize)``, is excluded
+so that its mutable contents (UUIDs, signatures, counters) can be
+modified post-signing without invalidating the signature.
+
+See :ref:`chapter-binary-trailer` for the byte-level details and
+verification procedure.
+
+Relationship to per-configuration signing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whole-FIT signing protects the FIT as a whole; per-configuration
+signing protects each configuration individually. They are
+complementary:
+
+- A whole-FIT signature alone authenticates the FIT bytes but does
+  not bind specific images to specific configurations. If the
+  bootloader supports configuration selection by external means
+  (e.g. board compatibility), per-configuration signing is still
+  needed to prevent mix-and-match attacks within an authenticated
+  FIT.
+- Per-configuration signing alone provides the mix-and-match
+  protection but requires a full FDT parser to be exposed to
+  unauthenticated input.
+- A FIT carrying both provides the strongest guarantees: the FDT is
+  authenticated before it is parsed (whole-FIT) and individual
+  configurations are bound to their image sets (per-configuration).
+
+The ``compatible`` property used for configuration matching is
+included in the configuration node and therefore covered by
+per-configuration signing, but not by whole-FIT signing in any
+distinguishing way (whole-FIT signing covers all FDT bytes
+indiscriminately). This means a bootloader relying solely on
+whole-FIT signing could still be tricked by attacker-modified
+``compatible`` strings into selecting a different configuration than
+intended. Combining the two schemes closes this gap.
+
+Multiple signatures
+~~~~~~~~~~~~~~~~~~~
+
+The trailer can carry multiple ``signature-N`` properties for key
+rotation, multi-party signing or algorithm migration. All
+signatures cover the same byte ranges; they differ only in
+algorithm and key. Bootloader policy determines whether a single
+valid signature is sufficient or whether all must verify.
+
+Threat model
+~~~~~~~~~~~~
+
+This subsection summarises what whole-FIT signing protects against
+and what it does not, and how it compares to per-configuration
+signing.
+
+What whole-FIT signing protects against
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **Tampering with FDT content.** Any modification to the main
+  FDT's structure, strings or memreserve blocks changes bytes in
+  the signed range, invalidating the signature.
+- **Tampering with external image data.** The signed range extends
+  to ``totalsize + boot_cpuid_phys``, covering all external image
+  data.
+- **FDT-pointer redirection.** ``totalsize``, ``off_dt_struct``,
+  ``off_dt_strings`` and ``off_mem_rsvmap`` are all in the signed
+  FDT header. An attacker cannot redirect an FDT consumer to parse
+  attacker-controlled bytes by manipulating these fields.
+- **Truncation and extension.** ``totalsize`` and
+  ``boot_cpuid_phys`` are signed, so an attacker cannot shrink the
+  apparent extent of the FIT to excise content from the hash, nor
+  extend it to smuggle data into a verified region.
+- **Bit rot in regions not covered by per-configuration signing.**
+  Per-configuration signing is selective and does not hash, for
+  example, configuration nodes other than the one being signed,
+  unreferenced image nodes, or the FDT's strings block tail.
+  Whole-FIT signing covers all of these as raw bytes.
+- **Adversarial input to a full FDT parser.** A bootloader can
+  verify the whole-FIT signature using only a small fixed-offset
+  reader, before invoking libfdt or any equivalent. This shrinks
+  the pre-authentication attack surface to the verifier itself
+  plus the constrained-FDT trailer parser.
+
+What whole-FIT signing does *not* protect against
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **Mix-and-match attacks within an authenticated FIT.** Whole-FIT
+  signing certifies the FDT bytes as a whole, but it does not bind
+  specific images to specific configurations. A bootloader that
+  verifies only the whole-FIT signature and then chooses a
+  configuration based on, for example, ``compatible`` matching can
+  still be tricked into selecting an attacker-favoured
+  configuration if the FIT genuinely contains multiple
+  configurations and the attacker controls the matching input.
+  Per-configuration signing is required to prevent this.
+- **Modification of the trailer.** The trailer (UUIDs, signatures,
+  counters) is intentionally excluded from the signed range. An
+  attacker with write access to the boot medium can modify trailer
+  contents freely. Trailer values used for security-relevant
+  decisions (e.g. install UUIDs influencing update targeting) shall
+  be cross-checked against an authenticated source.
+- **Downgrade attacks against the signing scheme itself.** If the
+  bootloader policy is "verify a whole-FIT signature if one is
+  present, otherwise allow the FIT to boot", an attacker can strip
+  the trailer's signatures (or the trailer entirely) to bypass
+  whole-FIT verification. The defence is at policy level: a
+  bootloader requiring whole-FIT signing must not fall back to
+  unsigned operation. ``boot_cpuid_phys`` and the FDT magic are
+  both signed, so a downgrade attack must work at the policy
+  layer, not the format layer.
+- **Rollback and replay.** Neither whole-FIT signing nor
+  per-configuration signing prevents an attacker from booting a
+  previously valid (but now superseded) FIT. Anti-rollback
+  requires an authenticated version counter, typically held in
+  hardware (e.g. fuses) and checked by the bootloader against a
+  signed version field in the FIT.
+- **Compromise of the signing key.** Whole-FIT signing inherits
+  the security of the signature algorithm and key management. Key
+  rotation is supported via multiple ``signature-N`` properties,
+  but an attacker who obtains a valid private key can produce
+  authentic-looking FITs.
+
+Comparison with per-configuration signing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+================================  =============  ===========
+Threat                            Per-config     Whole-FIT
+================================  =============  ===========
+FDT content tampering             Selective      Yes
+External image data tampering     Via hash node  Yes
+Mix-and-match within FIT          Yes            No
+FDT-pointer redirection           Indirect       Yes
+File truncation / extension       No             Yes
+Pre-auth parser attack surface    libfdt         Trivial
+================================  =============  ===========
+
+The two schemes are complementary. A FIT carrying both gets the
+mix-and-match resistance of per-configuration signing and the
+small pre-authentication attack surface of whole-FIT signing.
+
 .. sectionauthor:: Simon Glass <sjg@chromium.org>

--- a/source/chapter7-security.rst
+++ b/source/chapter7-security.rst
@@ -492,11 +492,14 @@ A whole-FIT signature covers two byte ranges, in this order:
    ``totalsize`` keeps every header field stable, so the entire header
    is signed without exclusions. This authenticates the FDT's
    internal layout (``totalsize``, ``off_dt_struct``, ``off_dt_strings``,
-   ``off_mem_rsvmap``) as well as the external data extent
-   (``boot_cpuid_phys``).
-#. ``[0x28 + trailer_totalsize, totalsize + boot_cpuid_phys)`` —
+   ``off_mem_rsvmap``).
+#. ``[0x28 + trailer_totalsize, totalsize + external_data_size)`` —
    the main FDT's memreserve, structure and strings blocks, followed
-   by all external image data.
+   by all external image data, where ``external_data_size`` is the
+   value of the trailer's ``external-data-size`` property (zero if
+   absent). The property is implicitly authenticated by the
+   signature: any change to it shifts the upper bound of range 2 and
+   invalidates the hash.
 
 The trailer itself, ``[0x28, 0x28 + trailer_totalsize)``, is excluded
 so that its mutable contents (UUIDs, signatures, counters) can be
@@ -557,16 +560,18 @@ What whole-FIT signing protects against
   FDT's structure, strings or memreserve blocks changes bytes in
   the signed range, invalidating the signature.
 - **Tampering with external image data.** The signed range extends
-  to ``totalsize + boot_cpuid_phys``, covering all external image
-  data.
+  to ``totalsize + external_data_size``, covering all external
+  image data.
 - **FDT-pointer redirection.** ``totalsize``, ``off_dt_struct``,
   ``off_dt_strings`` and ``off_mem_rsvmap`` are all in the signed
   FDT header. An attacker cannot redirect an FDT consumer to parse
   attacker-controlled bytes by manipulating these fields.
-- **Truncation and extension.** ``totalsize`` and
-  ``boot_cpuid_phys`` are signed, so an attacker cannot shrink the
-  apparent extent of the FIT to excise content from the hash, nor
-  extend it to smuggle data into a verified region.
+- **Truncation and extension.** ``totalsize`` is in the signed
+  header and ``external-data-size`` is implicitly authenticated by
+  the signature (any change shifts the byte range and breaks the
+  hash), so an attacker cannot shrink the apparent extent of the
+  FIT to excise content, nor extend it to smuggle data into a
+  verified region.
 - **Bit rot in regions not covered by per-configuration signing.**
   Per-configuration signing is selective and does not hash, for
   example, configuration nodes other than the one being signed,
@@ -602,9 +607,9 @@ What whole-FIT signing does *not* protect against
   the trailer's signatures (or the trailer entirely) to bypass
   whole-FIT verification. The defence is at policy level: a
   bootloader requiring whole-FIT signing must not fall back to
-  unsigned operation. ``boot_cpuid_phys`` and the FDT magic are
-  both signed, so a downgrade attack must work at the policy
-  layer, not the format layer.
+  unsigned operation. The FDT magic and the rest of the header are
+  signed, so a downgrade attack must work at the policy layer, not
+  the format layer.
 - **Rollback and replay.** Neither whole-FIT signing nor
   per-configuration signing prevents an attacker from booting a
   previously valid (but now superseded) FIT. Anti-rollback

--- a/source/chapter8-binary-trailer.rst
+++ b/source/chapter8-binary-trailer.rst
@@ -76,15 +76,18 @@ The main FDT therefore looks like this:
            v     v             v                           v
            [hdr] [trailer FDT] [memrsv | struct | strings]
 
-External image data follows the main FDT, and ``boot_cpuid_phys``
-in the FDT header records its size:
+External image data follows the main FDT, and the trailer's
+``external-data-size`` property records its size:
 
 .. code-block::
 
-    offset 0                 totalsize    totalsize + boot_cpuid_phys
+    offset 0                 totalsize    totalsize + ext_size
            |                 |            |
            v                 v            v
            [main FDT, including trailer]  [external image data]
+
+where ``ext_size`` is the value of the trailer's
+``external-data-size`` property (zero if absent).
 
 Compatibility with existing FITs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -120,21 +123,30 @@ read from the trailer.
 External data size
 ~~~~~~~~~~~~~~~~~~
 
-The ``boot_cpuid_phys`` field of the main FDT header (offset
-``0x1c``, four bytes, big-endian) carries the size of the external
-data region in bytes — the number of bytes after the main FDT's
-``totalsize`` that contain externally stored image data. FIT does
-not otherwise use this field. A FIT with no external data sets it
-to zero.
+The number of bytes of external image data — the bytes after the
+main FDT's ``totalsize`` — is recorded in the trailer's root node
+as the ``external-data-size`` property (defined in
+`Trailer property catalogue`_). The value is a 64-bit big-endian
+integer, so the external data region is not constrained by any
+header-field width.
 
-This value is required for whole-FIT signing because it defines the
-extent of the authenticated content. Producers that emit a
-whole-FIT signature shall set ``boot_cpuid_phys`` accurately.
+Although the trailer is excluded from the whole-FIT signature,
+``external-data-size`` is *implicitly authenticated* by it: the
+signature is computed over a byte range whose upper bound depends
+on this value, so any tampering shifts the byte range and causes
+the signature check to fail. See `Whole-FIT signing`_ below for
+the exact range and verification procedure.
 
-Because the field is 32 bits, the external data region is limited
-to 4 GiB. A FIT with more than 4 GiB of external data cannot use
-whole-FIT signing under this scheme. In practice this is not a
-constraint, since FITs of that size are rare.
+A FIT with no external data either omits the property or sets it
+to zero. Producers that emit a whole-FIT signature shall set
+``external-data-size`` accurately.
+
+The ``boot_cpuid_phys`` field of the main FDT header is not used
+by FIT. Producers shall set it to zero; consumers shall ignore its
+value. Mandating a fixed value removes a producer-controlled byte
+range from the signed header, eliminating a covert channel and
+keeping the signed header's content fully determined by the FIT
+specification.
 
 
 Constrained FDT profile
@@ -284,6 +296,23 @@ treating them as an error.
 The ``vendor-`` prefix is reserved for vendor-defined properties
 that will never be standardised by this specification.
 
+external-data-size
+    The size in bytes of the external image data region — the bytes
+    after the main FDT's ``totalsize``. The value is a 64-bit
+    big-endian integer stored as 8 bytes, with the high 32 bits
+    first. A 64-bit value avoids the 4 GiB ceiling that a 32-bit
+    FDT header field would impose.
+
+    The all-zero value (or absence of the property) indicates no
+    external data. A producer that emits a whole-FIT signature shall
+    set this property to the actual external-data length.
+
+    The property is not signed directly, but is implicitly
+    authenticated by the whole-FIT signature: the signed byte range
+    extends to ``totalsize + external_data_size``, so any change to
+    the value shifts the range and invalidates the signature. See
+    `Whole-FIT signing`_ below.
+
 install-uuid
     A 16-byte RFC 4122 UUID identifying a particular installation
     of this FIT on persistent storage.
@@ -354,9 +383,11 @@ Signed byte ranges
 The signature covers two byte ranges, in this order:
 
 #. ``[0, 0x28)`` — the FDT header (40 bytes).
-#. ``[0x28 + trailer_totalsize, totalsize + boot_cpuid_phys)`` —
+#. ``[0x28 + trailer_totalsize, totalsize + external_data_size)`` —
    the main FDT's memreserve, structure and strings blocks,
-   followed by all external image data.
+   followed by all external image data, where
+   ``external_data_size`` is the value of the trailer's
+   ``external-data-size`` property (zero if absent).
 
 The hash is computed over the concatenation of these two ranges in
 order. The bytes between them, ``[0x28, 0x28 + trailer_totalsize)``,
@@ -368,16 +399,18 @@ Properties of the signed ranges
 
 - The full FDT header is signed (range 1), so an attacker cannot
   tamper with ``totalsize``, ``off_dt_struct``, ``off_dt_strings``,
-  ``off_mem_rsvmap``, ``boot_cpuid_phys`` or any other header
-  field. The FIT layout is fully authenticated.
+  ``off_mem_rsvmap`` or any other header field. The FIT layout is
+  fully authenticated.
 - The trailer's ``totalsize`` is in the trailer's FDT header, which
   is *inside* the excluded trailer region — but it cannot be
   tampered with for an attack: changing it would shift the start
   of range 2, causing the verifier to hash different bytes than
   the signer, and the signature would fail.
-- Range 2 is bounded above by ``totalsize + boot_cpuid_phys``,
-  both of which are signed. An attacker cannot shrink the range to
-  excise external data from the hash.
+- ``external-data-size`` lives in the (excluded) trailer body but
+  is similarly anchored: it determines the upper bound of range 2,
+  so any change shifts the hash input and invalidates the
+  signature. An attacker cannot shrink range 2 to excise external
+  data, nor extend it to include attacker-controlled bytes.
 
 Verification procedure
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -386,10 +419,12 @@ A verifier:
 
 #. Reads ``trailer_totalsize`` from the trailer's FDT header
    (offset ``0x2c``).
-#. Reads the main FDT's ``totalsize`` (offset ``0x4``) and
-   ``boot_cpuid_phys`` (offset ``0x1c``).
+#. Parses the trailer with the constrained-FDT parser to obtain
+   the value of ``external-data-size`` (zero if the property is
+   absent).
+#. Reads the main FDT's ``totalsize`` (offset ``0x4``).
 #. Hashes ``[0, 0x28)`` followed by
-   ``[0x28 + trailer_totalsize, totalsize + boot_cpuid_phys)``.
+   ``[0x28 + trailer_totalsize, totalsize + external_data_size)``.
 #. For each ``signature-N`` property in the trailer (starting at
    ``signature-1`` and stopping at the first missing number),
    verifies the hash against the signature using the algorithm and

--- a/source/chapter8-binary-trailer.rst
+++ b/source/chapter8-binary-trailer.rst
@@ -1,0 +1,421 @@
+.. SPDX-License-Identifier: GPL-2.0+
+
+.. _chapter-binary-trailer:
+
+Binary Trailer
+==============
+
+Introduction
+------------
+
+A FIT may carry a *binary trailer* placed immediately after the
+FIT's FDT header. The trailer holds data that is intentionally not
+covered by FIT signatures, including:
+
+- mutable per-installation metadata that must be updatable without
+  re-signing the FIT (e.g. an installation UUID), and
+- detached signatures that gate verification of the rest of the FIT
+  and therefore cannot live inside the data they sign.
+
+The trailer is a self-contained FDT blob restricted to a profile that
+allows it to be parsed before authentication by a small, auditable
+parser. This avoids exposing a general-purpose FDT parser to
+adversarial input while reusing the FDT format for tooling and
+extensibility.
+
+The trailer is **fixed in size and position** at producer time. Its
+internal contents are mutable post-signing — installation tooling
+can add, remove or modify properties — but the trailer's overall
+``totalsize`` does not change. This stability is what allows whole-
+FIT signing to cover the FIT as a single contiguous byte range
+without having to exclude any FDT header fields. Producers
+pre-allocate enough trailer space (e.g. 4 KiB) to accommodate
+expected modifications; the unused space is held as
+:ref:`padding <trailer-padding>`.
+
+Placing the trailer in the file prefix means a consumer can read and
+validate it without seeking past the rest of the FDT or the external
+image data. This is useful for streaming, network boot and A/B slot
+selection, where a peek at trailer metadata may inform whether to
+fetch the rest of the FIT.
+
+
+Location
+--------
+
+The trailer occupies the bytes immediately after the FIT's FDT
+header. For FDT version 17 (the version mandated by FIT, see
+:ref:`chapter-source-file-format`) the FDT header is ``0x28`` bytes
+long, so the trailer starts at file offset ``0x28``. The main FDT's
+``off_mem_rsvmap``, ``off_dt_struct`` and ``off_dt_strings`` fields
+all advance past the trailer so that libfdt sees a valid FDT.
+
+This specification assumes the FDT v17 header size of ``0x28``
+bytes. All references to ``0x28`` in this chapter are
+``sizeof(struct fdt_header)`` for v17. If a future FDT specification
+defines a larger header, this trailer scheme would need a
+corresponding update; ``0x28`` is treated as a fixed constant here
+to keep the pre-authentication parser simple.
+
+A consumer locates the trailer as follows:
+
+#. Read four bytes at offset ``0x28``. If the value is not the FDT
+   magic (``0xd00dfeed``), no trailer is present.
+#. Otherwise, read the trailer's own FDT header and obtain its
+   ``totalsize``.
+#. Verify that ``0x28 + trailer_totalsize`` is not greater than
+   ``totalsize`` (the main FDT's totalsize, which encompasses the
+   trailer).
+
+The main FDT therefore looks like this:
+
+.. code-block::
+
+    offset 0     0x28          0x28+T                      totalsize
+           |     |             |                           |
+           v     v             v                           v
+           [hdr] [trailer FDT] [memrsv | struct | strings]
+
+External image data follows the main FDT, and ``boot_cpuid_phys``
+in the FDT header records its size:
+
+.. code-block::
+
+    offset 0                 totalsize    totalsize + boot_cpuid_phys
+           |                 |            |
+           v                 v            v
+           [main FDT, including trailer]  [external image data]
+
+Compatibility with existing FITs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This scheme is designed to be safe to apply to any FIT:
+
+- A pre-existing FIT (no trailer) has its memreserve block
+  immediately after the FDT header at offset ``0x28``. The
+  consumer reads four bytes at ``0x28``, sees the start of the
+  memreserve block (which begins with the high 32 bits of an
+  address — almost always zero), fails the magic check, and
+  concludes correctly that no trailer is present.
+
+- A new-style FIT carries a real trailer at ``0x28``, identified
+  by FDT magic. The main FDT's ``off_mem_rsvmap`` points past the
+  trailer to where the memreserve block actually begins.
+
+A consumer that does not understand the trailer scheme parses the
+FDT in the standard way using ``off_mem_rsvmap``, ``off_dt_struct``
+and ``off_dt_strings``, and never inspects the bytes between the
+header and the memreserve block. Such a consumer remains compatible
+with FITs that carry a trailer.
+
+Producers must update ``off_mem_rsvmap``, ``off_dt_struct`` and
+``off_dt_strings`` to skip past the trailer when emitting one.
+``totalsize`` must also encompass the trailer.
+
+The trailer is **outside the signed regions of the FIT** (see
+`Whole-FIT signing`_ below) and is therefore unsigned. A consumer
+shall apply its own validation policy before relying on any value
+read from the trailer.
+
+External data size
+~~~~~~~~~~~~~~~~~~
+
+The ``boot_cpuid_phys`` field of the main FDT header (offset
+``0x1c``, four bytes, big-endian) carries the size of the external
+data region in bytes — the number of bytes after the main FDT's
+``totalsize`` that contain externally stored image data. FIT does
+not otherwise use this field. A FIT with no external data sets it
+to zero.
+
+This value is required for whole-FIT signing because it defines the
+extent of the authenticated content. Producers that emit a
+whole-FIT signature shall set ``boot_cpuid_phys`` accurately.
+
+Because the field is 32 bits, the external data region is limited
+to 4 GiB. A FIT with more than 4 GiB of external data cannot use
+whole-FIT signing under this scheme. In practice this is not a
+constraint, since FITs of that size are rare.
+
+
+Constrained FDT profile
+-----------------------
+
+The trailer is a valid FDT but restricted to the profile defined
+below. A producer that emits a trailer shall conform to this profile;
+a consumer shall reject any trailer that does not.
+
+Header
+~~~~~~
+
+- ``magic`` shall be ``0xd00dfeed``.
+- ``version`` shall be ``17``.
+- ``last_comp_version`` shall be ``17`` or less.
+- ``totalsize`` shall be at most 65536 bytes.
+- ``off_mem_rsvmap`` shall equal ``sizeof(struct fdt_header)`` (``0x28``).
+- The structure block and strings block shall not overlap each other,
+  the FDT header, or the memory reservation block.
+- All offsets and sizes shall fit within ``totalsize``.
+
+Memory reservation block
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The memory reservation block shall contain exactly one entry: the
+16-byte all-zero terminator. The trailer shall not carry memory
+reservations.
+
+Structure block
+~~~~~~~~~~~~~~~
+
+- The trailer contains a single root node.
+- The root node carries properties only. Sub-nodes are not permitted.
+- The root node's unit name shall be the empty string.
+- Allowed tokens are ``FDT_BEGIN_NODE``, ``FDT_END_NODE``, ``FDT_PROP``,
+  ``FDT_NOP`` and ``FDT_END``.
+- ``FDT_NOP`` tokens are permitted anywhere and shall be skipped by
+  the parser.
+- Each property name offset shall point inside the strings block and
+  shall reference a null-terminated string.
+
+Strings block
+~~~~~~~~~~~~~
+
+A standard FDT strings block. No additional constraints beyond those
+implied by the property-name rule above.
+
+Phandles, aliases, ``/chosen``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Not used. The trailer carries no nodes other than the root, so
+phandle-based references are meaningless in this context.
+
+.. _trailer-padding:
+
+Padding for in-place modification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The trailer's ``totalsize`` is fixed at producer time and shall not
+change after signing. Producers should allocate the trailer
+generously to leave room for future modifications. Unused space
+within the trailer takes one of two forms:
+
+- ``FDT_NOP`` tokens at the end of the structure block. These are
+  consumed by the parser as no-ops and may be replaced by
+  ``FDT_PROP`` tokens when adding properties.
+- Unused bytes after the strings block, before ``totalsize``.
+  These accommodate growth of the strings block when new property
+  names are added.
+
+A producer that wishes to permit later in-place modification shall
+ensure that both forms of padding are available. Tooling that
+modifies the trailer (e.g. ``fdtput`` to stamp ``install-uuid``)
+shall consume from these padding regions rather than changing
+``totalsize``.
+
+A FIT that runs out of trailer space cannot be modified in place.
+Such a FIT must be reissued with a larger trailer, which requires
+re-signing.
+
+
+Parser requirements
+-------------------
+
+A consumer parsing the trailer before authentication shall use a
+parser with the following properties:
+
+- No dynamic memory allocation.
+- No recursion.
+- All offsets and lengths bounds-checked against ``totalsize``.
+- A hard upper bound on input size of 65536 bytes.
+- Rejects any input that violates the profile above.
+
+A reference implementation in approximately 200 lines of C is
+available; see issue #48 in the upstream repository. Implementations
+are encouraged to use this or a similarly minimal parser, rather than
+a general-purpose FDT library, to limit the attack surface exposed to
+unauthenticated input.
+
+A consumer that does not require trailer contents may ignore the
+trailer entirely. The trailer is optional; absence is signalled by
+the absence of the FDT magic at offset ``0x28``.
+
+
+Producer behaviour
+------------------
+
+Producers (e.g. mkimage) shall emit trailers conforming to the
+profile above. In particular, producers shall not invoke libfdt
+operations that may introduce sub-nodes, memory reservations or
+other features outside the profile.
+
+When emitting a trailer, the producer shall:
+
+- Place the trailer at file offset ``0x28``, immediately after the
+  main FDT header.
+- Choose a fixed trailer ``totalsize``, generous enough to
+  accommodate expected post-signing modifications.
+- Pad the trailer's structure and strings blocks as described in
+  :ref:`trailer-padding`.
+- Update the main FDT's ``totalsize`` to encompass the trailer.
+- Update ``off_mem_rsvmap``, ``off_dt_struct`` and ``off_dt_strings``
+  to skip past the trailer.
+
+The trailer's ``totalsize`` shall not change after signing.
+
+Producers shall not invoke ``fdt_open_into()`` or equivalent
+operations that re-pack the main FDT, as these will overwrite the
+trailer region.
+
+Standard FDT tooling (``fdtget``, ``fdtput``, ``fdtdump``) operating
+on a trailer-only FDT remains conforming as long as no sub-nodes
+are added and the trailer's ``totalsize`` is preserved. ``fdtput``
+operating on the trailer in place will consume padding to absorb
+size changes. Installation tooling may use it to stamp values such
+as ``install-uuid``.
+
+
+Defined trailer properties
+--------------------------
+
+The following property names are defined by this specification.
+Other property names in the trailer's root node are reserved for
+future revisions; consumers shall skip unknown properties without
+treating them as an error.
+
+The ``vendor-`` prefix is reserved for vendor-defined properties
+that will never be standardised by this specification.
+
+install-uuid
+    A 16-byte RFC 4122 UUID identifying a particular installation
+    of this FIT on persistent storage.
+
+    Installation tooling stamps a fresh UUID at install time. An
+    all-zero value (16 bytes of ``0x00``) is the build-time
+    placeholder; consumers shall treat it as if the property is
+    absent.
+
+    The value is not integrity-protected. Systems that use it for
+    update-critical decisions (e.g. selecting an update target
+    partition) shall cross-check it against an authenticated source.
+
+signature-N
+    An opaque byte sequence carrying a detached signature over the
+    FIT's content, excluding the trailer itself. The exact byte
+    ranges are defined in `Whole-FIT signing`_.
+
+    Multiple signatures are supported via the suffix ``N``, which
+    is a positive integer starting at ``1``. A FIT carrying a single
+    signature uses ``signature-1``; further signatures use
+    ``signature-2``, ``signature-3`` and so on. Numbers shall be
+    contiguous starting from ``1``; consumers stop enumerating at
+    the first missing number.
+
+    Multiple signatures support key rotation, multi-party signing
+    and algorithm migration. All signatures cover the same byte
+    ranges; they differ only in algorithm and key.
+
+    Bootloader policy determines whether one valid signature is
+    sufficient (try each in turn until one succeeds) or whether all
+    must verify. This is a policy decision, not a format decision.
+
+    The signature algorithm and key for ``signature-N`` are
+    determined either by consumer policy (e.g. compiled-in or
+    fuse-derived) or by the companion ``signature-N-algo`` and
+    ``signature-N-key-hint`` properties below.
+
+signature-N-algo
+    A null-terminated string identifying the signature algorithm
+    used for ``signature-N``, e.g. ``"sha256,rsa2048"``. The syntax
+    matches the per-configuration ``algo`` property defined in
+    :ref:`chapter-source-file-format`.
+
+signature-N-key-hint
+    A null-terminated string identifying the public key used to
+    verify ``signature-N``. The consumer maps this hint to a
+    trusted public key in its key store.
+
+
+Whole-FIT signing
+-----------------
+
+A whole-FIT signature stored in a ``signature-N`` property covers
+everything in the FIT except the trailer's contents. The trailer's
+``totalsize`` is fixed at producer time (:ref:`trailer-padding`),
+so the position and extent of every other byte in the FIT are
+stable. This includes the FDT header fields, which are fully signed
+without exclusions.
+
+The same signed byte range is used by every ``signature-N``
+property; multiple signatures over the same content support key
+rotation, multi-party signing and algorithm migration.
+
+Signed byte ranges
+~~~~~~~~~~~~~~~~~~
+
+The signature covers two byte ranges, in this order:
+
+#. ``[0, 0x28)`` — the FDT header (40 bytes).
+#. ``[0x28 + trailer_totalsize, totalsize + boot_cpuid_phys)`` —
+   the main FDT's memreserve, structure and strings blocks,
+   followed by all external image data.
+
+The hash is computed over the concatenation of these two ranges in
+order. The bytes between them, ``[0x28, 0x28 + trailer_totalsize)``,
+are the trailer; they are excluded from the hash so that the
+trailer's contents can be modified post-signing.
+
+Properties of the signed ranges
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The full FDT header is signed (range 1), so an attacker cannot
+  tamper with ``totalsize``, ``off_dt_struct``, ``off_dt_strings``,
+  ``off_mem_rsvmap``, ``boot_cpuid_phys`` or any other header
+  field. The FIT layout is fully authenticated.
+- The trailer's ``totalsize`` is in the trailer's FDT header, which
+  is *inside* the excluded trailer region — but it cannot be
+  tampered with for an attack: changing it would shift the start
+  of range 2, causing the verifier to hash different bytes than
+  the signer, and the signature would fail.
+- Range 2 is bounded above by ``totalsize + boot_cpuid_phys``,
+  both of which are signed. An attacker cannot shrink the range to
+  excise external data from the hash.
+
+Verification procedure
+~~~~~~~~~~~~~~~~~~~~~~
+
+A verifier:
+
+#. Reads ``trailer_totalsize`` from the trailer's FDT header
+   (offset ``0x2c``).
+#. Reads the main FDT's ``totalsize`` (offset ``0x4``) and
+   ``boot_cpuid_phys`` (offset ``0x1c``).
+#. Hashes ``[0, 0x28)`` followed by
+   ``[0x28 + trailer_totalsize, totalsize + boot_cpuid_phys)``.
+#. For each ``signature-N`` property in the trailer (starting at
+   ``signature-1`` and stopping at the first missing number),
+   verifies the hash against the signature using the algorithm and
+   key indicated by ``signature-N-algo`` and ``signature-N-key-hint``
+   (or by consumer policy).
+#. Applies its policy: typically, accept if at least one signature
+   verifies; some deployments may require all to verify.
+
+
+Comparison with TLV trailer
+---------------------------
+
+An earlier proposal used a custom tag-length-value (TLV) encoding
+for the trailer. The constrained-FDT trailer described here was
+chosen for the following reasons:
+
+- One format is used throughout the FIT (FDT only) rather than two
+  (FDT plus TLV). There is no second tag registry to maintain and
+  no second encoding to specify, implement and test.
+- The pre-authentication parser is small and auditable in either
+  case, but the constrained-FDT parser also doubles as the format
+  consumed by standard tools, removing the need for a second
+  tooling stack.
+- FDT property values are limited only by the FDT format itself
+  (not by a 16-bit length field), which avoids future constraints
+  on signature or certificate-chain sizes.
+- New trailer entries are added by defining new property names,
+  using FDT's existing schema conventions, rather than by
+  allocating new TLV tags.

--- a/source/index.rst
+++ b/source/index.rst
@@ -16,6 +16,7 @@
    chapter5-source-file-format
    chapter6-usage
    chapter7-security
+   chapter8-binary-trailer
    references
 
 ..


### PR DESCRIPTION
A FIT may carry data that is intentionally not covered by FIT signatures: mutable per-installation metadata (e.g. install-uuid) that must be updatable without re-signing, and detached signatures that gate verification of the rest of the FIT and therefore cannot live inside the data they sign.

PR #44 places this data in a custom TLV trailer. Reviewer discussion on that PR raises two concerns:

- The TLV format is a second general-purpose data format alongside the FDT, requiring its own parser, schema and tooling.
- A pre-authentication parser must be hardened against adversarial input. libfdt is large and has historically had fuzzing bugs, ruling it out for this path.

Define the trailer as a constrained subset of FDT instead. The profile (single root node, properties only, version 17, capped at 64 KiB, no memory reservations beyond the terminator, no sub-nodes, no phandles) keeps the parser small and auditable while reusing the FDT format for tooling and extensibility. Issue #48 contains a reference parser in approximately 200 lines of C.

Place the trailer at file offset 0x28, immediately after the main FIT's FDT header, with a producer-chosen fixed totalsize that does not change post-signing. The main FDT's off_mem_rsvmap, off_dt_struct and off_dt_strings advance past the trailer so libfdt sees a valid FDT. This lets a consumer read the trailer from the file prefix without seeking past the rest of the FDT or external image data.

The trailer's totalsize is fixed at producer time so that the FIT's overall layout is stable. Internal mutability is provided by FDT_NOP padding in the structure block and unused space in the strings block, which together absorb size changes when properties are added, removed or modified post-signing.

Carry the external data size in the boot_cpuid_phys field of the main FDT header. This field defines the extent of external image data and is used by whole-FIT signing to identify the post-trailer content range.

Define whole-FIT signing as a hash over two byte ranges: the FDT header [0, 0x28) and the post-trailer content
[0x28 + trailer_totalsize, totalsize + boot_cpuid_phys). The full FDT header is signed because the trailer's fixed size keeps all header offsets stable. The trailer itself is excluded so that its contents may be modified post-signing.

Define the install-uuid, signature-N, signature-N-algo and signature-N-key-hint properties as the first members of the trailer namespace, with numbered signatures supporting key rotation and multi-party signing. Reserve the vendor- prefix for non-spec extensions.

Add a "Whole-FIT signing" section to chapter 7 (security) describing the scheme in security terms: how it complements per-configuration signing, what is signed, and a threat model covering what whole-FIT signing protects against (FDT tampering, pointer redirection, truncation, pre-auth parser attacks) and what it does not (mix-and- match within a FIT, trailer modification, downgrade attacks, rollback, key compromise).


Co-developed-by: Claude <noreply@anthropic.com>