### PR TITLE
conf.py: Find lightweight tags when computing the version

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -32,11 +32,11 @@ author = u'Marian Balakowicz <m8@semihalf.com>'
 # The short X.Y version
 try:
     version = str(subprocess.check_output(
-        ["git", "describe", "--exact-match"]), 'utf-8').strip()
+        ["git", "describe", "--tags", "--exact-match"]), 'utf-8').strip()
 except:
     try:
         version = str(subprocess.check_output(
-            ["git", "describe", "--dirty"]), 'utf-8').strip()
+            ["git", "describe", "--tags", "--dirty"]), 'utf-8').strip()
     except:
         version = "unknown-rev"
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
The 'git describe --exact-match' and 'git describe --dirty' calls only consider annotated tags. The tag-on-merge workflow added in the 1.0 commit creates lightweight tags, so a tagged release commit looks to git-describe as if no tag matches: it falls through to the '--dirty' branch, which also fails to find the lightweight tag and returns the previous tag plus a distance suffix. The resulting version string contains a hyphen, which conf.py treats as a draft qualifier and stamps the rendered PDF with a watermark.

Pass '--tags' to both git-describe invocations so lightweight tags are considered. A tagged release commit then yields a clean version string (e.g. 'v1.0') and an unwatermarked PDF.
