### PR TITLE
ci: Fetch tags before building so the version is clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,15 @@ jobs:
         pip3 install --user Sphinx
         pip3 install --user codespell
 
+    - name: fetch tags
+      # actions/checkout creates lightweight tags locally even when the
+      # source tag is annotated, which causes 'git describe --exact-match'
+      # to miss it. Refetching pulls the proper annotated tag.
+      run: git fetch --tags --force
+
     - name: build pdf
       run: |
         make latexpdf
-        git fetch --tags --force # Needed to make git-describe work
         mv build/latex/fit-specification.pdf build/latex/fit-specification-$(git describe).pdf
     - name: build html
       run: make html


### PR DESCRIPTION
## Summary

- Move `git fetch --tags --force` into its own step before `make latexpdf`
- Avoids the watermarked PDF that occurred for v1.0 because conf.py ran before the proper annotated tag was fetched

## Background

`actions/checkout@v4` stores the source tag as a lightweight reference locally even when it is annotated on the remote. conf.py's `git describe --exact-match` does not find lightweight tags, so the build at a tagged commit falls through to `--dirty` and returns a version string with a hyphen (e.g. `v0.8-32-gc210313`). The hyphen triggers conf.py's draft-watermark heuristic, so the rendered PDF was stamped with a watermark even on official release builds.

The workflow already ran `git fetch --tags --force` to pick up the proper annotated tag, but it did so after `make latexpdf`. This change moves the fetch into its own step ahead of the build so conf.py sees the annotated tag, returns a clean `v1.0` and produces an unwatermarked PDF.

## Test plan

- [ ] Push a tag (annotated or lightweight) and confirm the rendered PDF title says `Release vX.Y` (not `vX.Y-N-g...`)
- [ ] Confirm the resulting asset is `fit-specification-vX.Y.pdf` (not `fit-specification-v0.8-N-g...pdf`)
- [ ] Confirm no draft watermark appears on any page