### PR TITLE
chapter5: Deprecate the sign-images property

### DIFF
--- a/source/chapter5-source-file-format.rst
+++ b/source/chapter5-source-file-format.rst
@@ -499,10 +499,17 @@ key-name-hint
     <name>.crt.
 
 sign-images
-    An unsorted list of images to sign, each being a property of the conf
-    node that contains them. The default is "kernel,fdt" which means that these
-    two images will be looked up in the config and signed if present. This is
-    used by mkimage to determine which images to sign.
+    *Deprecated.* An unsorted list of property names on the parent
+    configuration node identifying the images to sign. New FITs shall
+    omit this property. The signer and verifier instead derive the
+    set of referenced images automatically from the configuration's
+    string properties as described in :ref:`hash_contents`. This
+    auto-discovery covers every image referenced by the configuration
+    without requiring producers to keep the list in sync.
+
+    Tools should ignore ``sign-images`` if present and apply the
+    auto-discovery rule unconditionally. A future revision of this
+    specification may remove the property entirely.
 
 The following properties are added as part of signing, and are mandatory:
 
@@ -866,7 +873,7 @@ Configuration-signature nodes
     o signature-1
         |- algo = "algorithm name"
         |- key-name-hint = "key name"
-        |- sign-images = "path1", "path2";
+        |- sign-images = "path1", "path2";  /* deprecated */
         |- value = [hash or checksum value]
         |- hashed-strings = <0 len>
 

--- a/source/chapter7-security.rst
+++ b/source/chapter7-security.rst
@@ -255,7 +255,6 @@ Consider the following minimal FIT source::
                 signature-1 {
                     algo = "sha256,rsa2048";
                     key-name-hint = "dev";
-                    sign-images = "kernel", "fdt";
                 };
             };
         };
@@ -309,7 +308,6 @@ resulting FIT looks like this::
                 signature-1 {
                     algo = "sha256,rsa2048";
                     key-name-hint = "dev";
-                    sign-images = "kernel", "fdt";
                     value = <...256-byte RSA-2048 signature...>;
                     hashed-nodes = "/", "/configurations/conf-1",
                         "/images/kernel", "/images/kernel/hash-1",
@@ -387,7 +385,6 @@ or its parent is in the node list.
                **signature-1 {**
                    algo = "sha256,rsa2048";
                    key-name-hint = "dev";
-                   sign-images = "kernel", "fdt";
                    value = <...256-byte RSA-2048 signature...>;
                    hashed-nodes = "/", "/configurations/conf-1", ...;
                    hashed-strings = <0x00000000 0x000000d4>;


### PR DESCRIPTION
PR #47 documents that the signer and verifier auto-discover image references from the configuration's string properties (excluding 'description', 'compatible' and 'default'). With auto-discovery in place, 'sign-images' becomes redundant in every case where it would list all images, and harmful in cases where it lists fewer (the verifier hashes a larger node set than the signer used).

Mark the property as deprecated. New FITs should omit it. Tools should ignore the property when present and apply the auto-discovery rule unconditionally; this avoids signer/verifier disagreement and removes the only viable failure mode of the property. A future revision may remove the property entirely.

Annotate the property in the configuration-signature structure diagram so readers see at a glance that the property is on its way out, and remove it from the chapter 7 worked example so the example reflects current best practice.


Co-developed-by: Claude <noreply@anthropic.com>