### PR TITLE
min_fdt: Minimal and secure FDT parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# C build artifacts
+*.o
+*.a
+
+# Sphinx output
+build/

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,16 @@ SOURCEDIR     = source
 BUILDDIR      = build
 LATEXDIFF     = latexdiff
 
+# Minimal FDT parser (issue #48). Built into a static library so that
+# consumers can link a single .a file. Override CC/AR/CFLAGS_MIN_FDT
+# from the command line for cross-compilation or stricter warnings.
+CC                 ?= cc
+AR                 ?= ar
+CFLAGS_MIN_FDT     ?= -Wall -Wextra -Wpedantic -O2 -fPIC
+MIN_FDT_DIR         = min_fdt
+MIN_FDT_OBJS        = $(MIN_FDT_DIR)/minimal_fdt.o
+MIN_FDT_LIB         = $(MIN_FDT_DIR)/libminfdt.a
+
 all: latexpdf html
 
 # Put it first so that "make" without argument is like "make help".
@@ -17,7 +27,23 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@echo "  latexdiff   to make LaTeX files including changebars against previous release"
 
-.PHONY: all help latexdiff Makefile
+.PHONY: all help latexdiff Makefile minfdt minfdt-clean clean
+
+minfdt: $(MIN_FDT_LIB)
+
+$(MIN_FDT_LIB): $(MIN_FDT_OBJS)
+	$(AR) rcs $@ $^
+
+$(MIN_FDT_DIR)/%.o: $(MIN_FDT_DIR)/%.c $(MIN_FDT_DIR)/minimal_fdt.h
+	$(CC) $(CFLAGS_MIN_FDT) -c -o $@ $<
+
+minfdt-clean:
+	rm -f $(MIN_FDT_OBJS) $(MIN_FDT_LIB)
+
+# Override the Sphinx catch-all so that 'make clean' wipes both the
+# Sphinx build tree and the minfdt artifacts.
+clean: minfdt-clean
+	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 latexdiff: latex
 	@echo "Generating LaTeX changebars..."

--- a/min_fdt/minimal_fdt.c
+++ b/min_fdt/minimal_fdt.c
@@ -1,0 +1,254 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+/*
+ * Minimal FDT parser - see minimal_fdt.h for the profile constraints
+ *
+ * No heap, no recursion, all bounds checked.  The state machine has
+ * four states - see enum parser_state.
+ */
+
+#include "minimal_fdt.h"
+#include <string.h>
+
+#define FDT_MAGIC		0xd00dfeed
+#define FDT_BEGIN_NODE		1
+#define FDT_END_NODE		2
+#define FDT_PROP		3
+#define FDT_NOP			4
+#define FDT_END			9
+
+#define FDT_HDR_SIZE		40
+#define FDT_MEMRSV_TERM_SIZE	16
+
+static inline uint32_t align4(uint32_t x)
+{
+	return (x + 3) & ~3;
+}
+
+/*
+ * Host-endian copy of the FDT header fields
+ *
+ * off_mem_rsvmap is validated below; boot_cpuid_phys is meaningless in
+ * a post-sign trailer and is deliberately not checked
+ */
+struct fdt_hdr {
+	uint32_t magic;
+	uint32_t totalsize;
+	uint32_t off_struct;
+	uint32_t off_strings;
+	uint32_t off_mem_rsvmap;
+	uint32_t version;
+	uint32_t last_comp_version;
+	uint32_t boot_cpuid_phys;
+	uint32_t size_strings;
+	uint32_t size_struct;
+};
+
+/*
+ * FDT_HDR_SIZE is a wire-format constant (Devicetree Specification, 5.2)
+ * and is parsed via explicit be32() reads, not memcpy.  Keep the host
+ * struct layout in step so that mismatches are caught at compile time.
+ */
+_Static_assert(sizeof(struct fdt_hdr) == FDT_HDR_SIZE,
+	       "fdt_hdr layout no longer matches the on-disk header size");
+
+/*
+ * Conceptual state of the structure-block walk.  Each FDT token either
+ * advances the state, leaves it unchanged (FDT_NOP), or is rejected as
+ * a structural error if it does not match the current state.
+ */
+enum parser_state {
+	BEFORE_ROOT,	/* no FDT_BEGIN_NODE yet */
+	IN_ROOT,	/* inside the single root node */
+	AFTER_ROOT,	/* root closed, awaiting FDT_END */
+	DONE,		/* FDT_END seen, loop exits */
+};
+
+static uint32_t be32(const uint8_t *p)
+{
+	return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
+	       ((uint32_t)p[2] << 8)  |  (uint32_t)p[3];
+}
+
+static void parse_hdr(const uint8_t *blob, struct fdt_hdr *hdr)
+{
+	hdr->magic		= be32(blob +  0);
+	hdr->totalsize		= be32(blob +  4);
+	hdr->off_struct		= be32(blob +  8);
+	hdr->off_strings	= be32(blob + 12);
+	hdr->off_mem_rsvmap	= be32(blob + 16);
+	hdr->version		= be32(blob + 20);
+	hdr->last_comp_version	= be32(blob + 24);
+	hdr->boot_cpuid_phys	= be32(blob + 28);
+	hdr->size_strings	= be32(blob + 32);
+	hdr->size_struct	= be32(blob + 36);
+}
+
+/*
+ * Validate the 40-byte header and populate hdr.  On success, all of
+ * hdr's offset/size fields are known to fit inside the blob and the
+ * struct and strings blocks do not overlap.
+ */
+static int validate_header(const uint8_t *blob, uint32_t size,
+			   struct fdt_hdr *hdr)
+{
+	int i;
+
+	if (size < FDT_HDR_SIZE)
+		return MFDT_ERR_TRUNCATED;
+	if (size > MFDT_MAX_SIZE)
+		return MFDT_ERR_TOOLARGE;
+
+	parse_hdr(blob, hdr);
+
+	if (hdr->magic != FDT_MAGIC)
+		return MFDT_ERR_BADMAGIC;
+	if (hdr->totalsize != size)
+		return MFDT_ERR_BADLAYOUT;
+	if (hdr->version != 17)
+		return MFDT_ERR_BADVERSION;
+	if (hdr->last_comp_version > 17)
+		return MFDT_ERR_BADVERSION;
+
+	/*
+	 * Memreserve block must immediately follow the header and contain
+	 * nothing but the 16-byte all-zero terminator (no reservations
+	 * are permitted in our trailer profile)
+	 */
+	if (hdr->off_mem_rsvmap != FDT_HDR_SIZE)
+		return MFDT_ERR_BADLAYOUT;
+	if (size < FDT_HDR_SIZE + FDT_MEMRSV_TERM_SIZE)
+		return MFDT_ERR_TRUNCATED;
+	for (i = 0; i < FDT_MEMRSV_TERM_SIZE; i++)
+		if (blob[FDT_HDR_SIZE + i])
+			return MFDT_ERR_BADLAYOUT;
+
+	if (hdr->off_struct & 3)
+		return MFDT_ERR_ALIGNMENT;
+	if (hdr->off_struct < FDT_HDR_SIZE + FDT_MEMRSV_TERM_SIZE ||
+	    hdr->off_struct > size ||
+	    hdr->size_struct > size - hdr->off_struct)
+		return MFDT_ERR_BADLAYOUT;
+	if (hdr->off_strings < FDT_HDR_SIZE + FDT_MEMRSV_TERM_SIZE ||
+	    hdr->off_strings > size ||
+	    hdr->size_strings > size - hdr->off_strings)
+		return MFDT_ERR_BADLAYOUT;
+	/* Reject overlapping struct/strings blocks */
+	if (hdr->off_struct < hdr->off_strings + hdr->size_strings &&
+	    hdr->off_strings < hdr->off_struct + hdr->size_struct)
+		return MFDT_ERR_BADLAYOUT;
+
+	return MFDT_OK;
+}
+
+int mfdt_parse(const uint8_t *blob, uint32_t size,
+	       mfdt_prop_callback callback, void *callback_ctx)
+{
+	enum parser_state state = BEFORE_ROOT;
+	struct fdt_hdr hdr;
+	const uint8_t *sb;
+	uint32_t pos = 0;
+	const char *st;
+	int ret;
+
+	ret = validate_header(blob, size, &hdr);
+	if (ret != MFDT_OK)
+		return ret;
+
+	sb = blob + hdr.off_struct;
+	st = (const char *)blob + hdr.off_strings;
+
+	while (pos + 4 <= hdr.size_struct && state != DONE) {
+		uint32_t tok = be32(sb + pos);
+
+		pos += 4;
+
+		switch (tok) {
+		case FDT_BEGIN_NODE:
+			if (state != BEFORE_ROOT)
+				return MFDT_ERR_BADSTRUCT;
+			if (pos >= hdr.size_struct)
+				return MFDT_ERR_TRUNCATED;
+			if (sb[pos])
+				return MFDT_ERR_BADSTRUCT;
+			pos = align4(pos + 1);
+			state = IN_ROOT;
+			break;
+		case FDT_END_NODE:
+			if (state != IN_ROOT)
+				return MFDT_ERR_BADSTRUCT;
+			state = AFTER_ROOT;
+			break;
+		case FDT_PROP: {
+			uint32_t plen, poff;
+
+			if (state != IN_ROOT)
+				return MFDT_ERR_BADSTRUCT;
+			if (pos + 8 > hdr.size_struct)
+				return MFDT_ERR_TRUNCATED;
+
+			plen = be32(sb + pos);
+			poff = be32(sb + pos + 4);
+			pos += 8;
+
+			if (plen > hdr.size_struct - pos)
+				return MFDT_ERR_TRUNCATED;
+			if (poff >= hdr.size_strings)
+				return MFDT_ERR_BADOFFSET;
+			if (!memchr(st + poff, 0, hdr.size_strings - poff))
+				return MFDT_ERR_BADOFFSET;
+
+			if (callback) {
+				int ret = callback(callback_ctx, st + poff,
+						   sb + pos, plen);
+				if (ret < 0)
+					return ret;
+			}
+
+			pos = align4(pos + plen);
+			break;
+		}
+		case FDT_NOP:
+			break;
+		case FDT_END:
+			if (state == IN_ROOT)
+				return MFDT_ERR_BADSTRUCT;
+			state = DONE;
+			break;
+		default:
+			return MFDT_ERR_BADSTRUCT;
+		}
+	}
+
+	if (state != DONE)
+		return MFDT_ERR_TRUNCATED;
+	/* FDT_END must be the last token - no trailing data allowed */
+	if (pos != hdr.size_struct)
+		return MFDT_ERR_BADSTRUCT;
+	return MFDT_OK;
+}
+
+const char *mfdt_strerror(int err)
+{
+	switch (err) {
+	case MFDT_OK:
+		return "ok";
+	case MFDT_ERR_BADOFFSET:
+		return "bad offset";
+	case MFDT_ERR_TRUNCATED:
+		return "truncated";
+	case MFDT_ERR_BADMAGIC:
+		return "bad magic";
+	case MFDT_ERR_BADVERSION:
+		return "bad version";
+	case MFDT_ERR_BADSTRUCT:
+		return "bad structure";
+	case MFDT_ERR_BADLAYOUT:
+		return "bad layout";
+	case MFDT_ERR_ALIGNMENT:
+		return "alignment error";
+	case MFDT_ERR_TOOLARGE:
+		return "blob too large";
+	default:
+		return "unknown error";
+	}
+}

--- a/min_fdt/minimal_fdt.h
+++ b/min_fdt/minimal_fdt.h
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+/*
+ * minimal_fdt.h - Minimal FDT parser for a constrained post-sign FIT trailer.
+ *
+ * The on-disk format is the standard Flattened Devicetree blob (DTB)
+ * defined by the Devicetree Specification - the same format consumed by
+ * libfdt and produced by dtc - so a blob that satisfies this parser
+ * also reads correctly with any conformant DT tool.  This parser only
+ * implements a small profile of that format: the blob is expected to
+ * contain a single root node with properties only - no sub-nodes, no
+ * phandles, no aliases.  That keeps the parser small and auditable
+ * without giving up interoperability with the wider DT ecosystem.
+ */
+
+#ifndef MINIMAL_FDT_H
+#define MINIMAL_FDT_H
+
+#include <stdint.h>
+
+/**
+ * DOC: Error codes
+ *
+ * Numbers are chosen to match libfdt's (negated) convention where the
+ * semantics overlap - see <libfdt.h>.  Codes with no libfdt equivalent
+ * use values past FDT_ERR_MAX (19).  mfdt_parse() returns int so a
+ * callback can propagate arbitrary negative values; named codes are
+ * still members of enum mfdt_err for debugger display and switch
+ * coverage.
+ */
+enum mfdt_err {
+	MFDT_OK			= 0,
+	MFDT_ERR_BADOFFSET	= -4,	/* property name offset OOB    */
+	MFDT_ERR_TRUNCATED	= -8,	/* blob too small, missing END */
+	MFDT_ERR_BADMAGIC	= -9,
+	MFDT_ERR_BADVERSION	= -10,	/* version != 17               */
+	MFDT_ERR_BADSTRUCT	= -11,	/* tokens, nesting, root name  */
+	MFDT_ERR_BADLAYOUT	= -12,	/* bounds, overlap, totalsize  */
+	MFDT_ERR_ALIGNMENT	= -19,
+	MFDT_ERR_TOOLARGE	= -50,	/* blob exceeds MFDT_MAX_SIZE  */
+};
+
+/** MFDT_MAX_SIZE - Hard upper bound on trailer size (64 KB). */
+#define MFDT_MAX_SIZE		(64 * 1024)
+
+/**
+ * typedef mfdt_prop_callback - Per-property callback fired during parsing
+ * @ctx: Caller-supplied context, passed through unchanged
+ * @name: NUL-terminated property name from the strings block
+ * @value: Pointer to the property value bytes (inside the blob)
+ * @len: Length of the value in bytes
+ *
+ * Fired once per property in the root node.  Return < 0 to stop parsing;
+ * that value is propagated directly as the parse return code.  Callbacks
+ * that want to avoid collision with parser codes should use values below
+ * -100.
+ *
+ * Return: 0 to continue, negative to stop parsing.
+ */
+typedef int (*mfdt_prop_callback)(void *ctx, const char *name,
+				  const uint8_t *value, uint32_t len);
+
+/**
+ * mfdt_parse() - Parse a minimal FDT blob
+ * @blob: Pointer to the blob bytes
+ * @size: Total size of the blob in bytes
+ * @callback: Per-property callback, or %NULL to validate only
+ * @callback_ctx: Opaque context passed to @callback
+ *
+ * Walks the structure block of @blob, calling @callback for each property
+ * in the root node.  All offsets and lengths are bounds-checked; the
+ * parser uses no heap and no recursion.
+ *
+ * Return: %MFDT_OK on success, or one of the negative MFDT_ERR_* codes on
+ *   failure.  If @callback returns a negative value the parser stops and
+ *   propagates that value.
+ */
+int mfdt_parse(const uint8_t *blob, uint32_t size,
+	       mfdt_prop_callback callback, void *callback_ctx);
+
+/**
+ * mfdt_strerror() - Translate an error code to a human-readable string
+ * @err: Error code returned by mfdt_parse()
+ *
+ * Return: Pointer to a static, NUL-terminated string describing @err.
+ *   Always non-%NULL; unknown codes return a generic message.
+ */
+const char *mfdt_strerror(int err);
+
+#endif /* MINIMAL_FDT_H */


### PR DESCRIPTION
## Summary

A minimal, auditable FDT parser intended for a constrained post-sign FIT trailer profile: one root node containing properties only - no sub-nodes, no phandles, no aliases.  The on-disk format is the standard Flattened Devicetree blob defined by the Devicetree Specification, so a blob that satisfies this parser also reads correctly with libfdt and any conformant DT tool.

Implements the proposal in #48.

## What's in it

- `min_fdt/minimal_fdt.h` - public interface, documented with kerneldoc.
- `min_fdt/minimal_fdt.c` - parser implementation: no heap, no
  recursion, every offset and length bounds-checked.
- `Makefile` - `make minfdt` builds `min_fdt/libminfdt.a`;
  `make clean` removes both the Sphinx build tree and the minfdt
  artifacts.
- `.gitignore` - ignores `*.o`, `*.a`, and `build/`.

## Design notes

- The header validation is split into a static `validate_header()` so
  that `mfdt_parse()` reads top-down as "check the header, walk the
  struct block".
- The token walk runs a four-state machine -
  `enum parser_state { BEFORE_ROOT, IN_ROOT, AFTER_ROOT, DONE }` -
  rather than the original tangle of three booleans.
- Error codes live in `enum mfdt_err`; the values are chosen to match
  libfdt's (negated) numbering where semantics overlap (see
  `<libfdt.h>`).  `mfdt_parse()` still returns plain `int` so a
  callback can propagate any negative value to abort parsing.
- `_Static_assert(sizeof(struct fdt_hdr) == FDT_HDR_SIZE, ...)` ties
  the host struct to the wire-format size without making the bounds
  checks depend on host struct layout.
- `mfdt_strerror()` returns a human-readable string for any error
  code, including a generic message for callback-supplied values.

## Test plan

- [ ] `make minfdt` produces `min_fdt/libminfdt.a` cleanly with
      `-Wall -Wextra -Wpedantic`.
- [ ] `make clean` removes both Sphinx and minfdt artifacts.
- [ ] Link against a small driver that feeds the parser known-good
      and known-bad FIT trailers and confirms the expected
      `MFDT_OK` / `MFDT_ERR_*` outcomes.