### PR TITLE
Define the cipher node and its interaction with image-data

### DIFF
--- a/source/chapter5-source-file-format.rst
+++ b/source/chapter5-source-file-format.rst
@@ -747,11 +747,14 @@ iv-name-hint
 iv
     The raw initialisation vector, as a byte array whose length matches the
     cipher's block size (16 bytes for AES). The IV is not secret, so it may
-    be carried in the FIT. A producer that is not given an ``iv-name-hint``
-    generates a fresh, random IV and stores it here.
+    be carried in the FIT. A producer given this property and no
+    ``iv-name-hint`` encrypts with exactly this IV. A producer given
+    neither property generates a fresh, random IV and stores it here.
 
-At least one of ``iv-name-hint`` or ``iv`` must be present, so that the
-consumer can obtain the IV needed to decrypt the data.
+In a resolved FIT at least one of ``iv-name-hint`` or ``iv`` must be
+present, so that the consumer can obtain the IV needed to decrypt the
+data. An authored FIT may omit both, in which case the producer
+generates a random IV and records it in ``iv``.
 
 Because the ``cipher`` node is included in the configuration signature (see
 :ref:`hash_contents`), its ``algo``, ``key-name-hint``, ``iv-name-hint`` and
@@ -860,10 +863,11 @@ reused IV, so it does not weaken the cipher.
 
 If the two nodes' cipher parameters would produce different ciphertext (for
 example a different ``algo``, key or IV, including the independent random IV
-that a producer generates when ``iv-name-hint`` is absent), then the data
-cannot be shared and the FIT is malformed; the producer must reject it. To
-share encrypted data, both nodes must therefore reference the same IV
-explicitly, normally by using the same ``iv-name-hint``.
+that a producer generates when a node provides neither ``iv-name-hint`` nor
+``iv``), then the data cannot be shared and the FIT is malformed; the
+producer must reject it. To share encrypted data, both nodes must therefore
+reference the same IV explicitly, through the same ``iv-name-hint`` or the
+same ``iv``.
 
 For example, the encrypted form of the sharing example above keeps a matching
 ``cipher`` sub-node on both nodes::
@@ -909,9 +913,10 @@ For example, the encrypted form of the sharing example above keeps a matching
 
 Both ``cipher`` sub-nodes use the same ``algo``, ``key-name-hint`` and
 ``iv-name-hint``, so the single shared ciphertext decrypts to the same
-plaintext for either node. Relying on the same ``iv-name-hint`` rather than a
-producer-generated random IV is what makes the shared ciphertext
-well-defined.
+plaintext for either node. Sharing one IV explicitly, whether through the
+same ``iv-name-hint`` as here or through the same ``iv`` value, rather than
+relying on a producer-generated random IV, is what makes the shared
+ciphertext well-defined.
 
 '/configurations' node
 ----------------------

--- a/source/chapter5-source-file-format.rst
+++ b/source/chapter5-source-file-format.rst
@@ -168,6 +168,7 @@ the '/images' node should have the following layout::
         o hash-1 {...}
         o hash-2 {...}
         o dm-verity {...}
+        o cipher {...}
         ...
 
 Mandatory properties
@@ -294,6 +295,14 @@ data-position
     Machine address at which the data is to be found. This is a fixed address
     not relative to the loading of the FIT. This is mandatory if
     :index:`external data` is used with a fixed address.
+
+data-size-unciphered
+    Size in bytes of the image's unencrypted (plaintext) data. This is
+    mandatory when the image node has a ``cipher`` sub-node (see
+    `Cipher nodes`_): in that case ``data`` holds padded ciphertext that is
+    larger than the plaintext, and the consumer uses this value to recover
+    the original data after decryption. Unlike the ``data`` properties above,
+    this property is covered by the configuration signature.
 
 os
     :index:`OS` name, mandatory for types "kernel". Valid OS names are:
@@ -424,6 +433,10 @@ dm-verity
     Merkle-tree metadata so that the bootloader can construct kernel
     command-line parameters for integrity-verified boot.
     See `dm-verity nodes`_.
+
+cipher
+    Describes how this image's data is encrypted, so that a consumer holding
+    the right key can decrypt it. See `Cipher nodes`_.
 
 .. index:: Hash nodes
 
@@ -653,6 +666,98 @@ kernel command line (see :ref:`verity-usage`).
 Both the filesystem payload data and the dm-verity Merkle-tree hash data are
 expected to reside inside the same sub-image.
 
+.. index:: Cipher nodes
+
+.. _cipher-nodes:
+
+Cipher nodes
+------------
+
+An image node may contain a ``cipher`` sub-node describing how the image data
+is encrypted, allowing a consumer that holds the right key to decrypt it.
+Encryption provides *confidentiality* for the image payload only; it does not
+provide authentication. Integrity and authenticity continue to come from the
+image hash and the configuration signature (see :ref:`chapter-security`).
+
+::
+
+    o cipher
+        |- algo = "encryption algorithm name"
+        |- key-name-hint = "key name"
+        |- iv-name-hint = "IV name"
+        |- iv = [initialisation vector bytes]
+
+When the ``cipher`` sub-node is present, the image node's ``data`` (or its
+external-data equivalent) holds the *ciphertext* instead of the plaintext, and
+the image node carries a ``data-size-unciphered`` property giving the size of
+the original plaintext.
+
+Mandatory properties
+~~~~~~~~~~~~~~~~~~~~
+
+algo
+    :index:`Encryption algorithm <pair: encryption; algorithm>` name. The
+    ``algo`` value is the sole identifier of the encryption scheme: it fully
+    determines the cipher, key length, mode of operation, IV size and
+    padding. There is no separate property for the mode or any other
+    parameter. The algorithms currently defined by this specification, with
+    their key sizes, are:
+
+    ==================== ============ =========================================
+    Algorithm            Key (bytes)  Meaning
+    ==================== ============ =========================================
+    aes128               16           AES-128 in CBC mode
+    aes192               24           AES-192 in CBC mode
+    aes256               32           AES-256 in CBC mode
+    ==================== ============ =========================================
+
+    This list is not closed: future revisions of this specification may
+    define further algorithms, so a consumer must treat an unrecognised
+    ``algo`` as an error (and therefore reject the image) rather than
+    assuming the data is unencrypted.
+
+    The three algorithms above use the Cipher Block Chaining (CBC) mode of
+    operation with a 16-byte initialisation vector and PKCS#7 padding.
+    Because the padding rounds the ciphertext up to a whole number of
+    16-byte blocks, the plaintext size is recorded separately in
+    ``data-size-unciphered``. A scheme that needs a different mode, IV size
+    or padding (for example an AEAD mode such as AES-GCM) is added as a new
+    ``algo`` value rather than by introducing further properties.
+
+key-name-hint
+    Name of the key used to encrypt the image. This is only a hint that lets
+    the FIT producer and consumer locate the key material; it is not the key.
+    The key itself is **not** stored in the FIT. A FIT is not a confidential
+    container, so the decryption key must be provisioned out-of-band into a
+    trusted, secret store held by the consumer (for example a key built into
+    the bootloader). How that store is organised, and how the hint is mapped
+    to a key, is consumer-defined and outside the scope of this
+    specification.
+
+Optional properties
+~~~~~~~~~~~~~~~~~~~
+
+iv-name-hint
+    Name of the :index:`initialisation vector` (IV) to use. Like
+    ``key-name-hint`` this is only a hint used to locate the IV in the
+    consumer's trusted store. When ``iv-name-hint`` is present the ``iv``
+    property is normally omitted from the FIT, since the consumer obtains the
+    IV from its store.
+
+iv
+    The raw initialisation vector, as a byte array whose length matches the
+    cipher's block size (16 bytes for AES). The IV is not secret, so it may
+    be carried in the FIT. A producer that is not given an ``iv-name-hint``
+    generates a fresh, random IV and stores it here.
+
+At least one of ``iv-name-hint`` or ``iv`` must be present, so that the
+consumer can obtain the IV needed to decrypt the data.
+
+Because the ``cipher`` node is included in the configuration signature (see
+:ref:`hash_contents`), its ``algo``, ``key-name-hint``, ``iv-name-hint`` and
+``iv`` values are authenticated, even though the key itself is not part of
+the FIT.
+
 .. _shared-image-data:
 
 Shared image data
@@ -733,6 +838,80 @@ set explicitly. Only the binary payload is shared.
 FIT consumers (e.g. bootloaders) shall ignore the ``image-data``
 property. The ``data``, ``data-offset`` and ``data-size`` properties are
 authoritative.
+
+Sharing encrypted image data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the source node is encrypted (carries a ``cipher`` sub-node, see
+`Cipher nodes`_), the bytes stored on disk (and therefore the bytes shared
+through ``image-data``) are the *ciphertext*. The sharing node must carry
+its own ``cipher`` sub-node, because no properties are inherited from the
+source. That ``cipher`` sub-node must describe the *same* ciphertext as the
+source: the same ``algo``, the same key (``key-name-hint``) and the same IV
+(the same ``iv-name-hint``, or the same explicit ``iv``). The
+``data-size-unciphered`` of the two nodes must also be equal, since the
+plaintext is identical.
+
+This is well-defined because AES-CBC is deterministic: a given plaintext,
+key and IV always produce the same ciphertext. Sharing that ciphertext
+between two nodes that use identical parameters is simply the same encrypted
+payload referenced twice; it is not two encryptions of different data under a
+reused IV, so it does not weaken the cipher.
+
+If the two nodes' cipher parameters would produce different ciphertext (for
+example a different ``algo``, key or IV, including the independent random IV
+that a producer generates when ``iv-name-hint`` is absent), then the data
+cannot be shared and the FIT is malformed; the producer must reject it. To
+share encrypted data, both nodes must therefore reference the same IV
+explicitly, normally by using the same ``iv-name-hint``.
+
+For example, the encrypted form of the sharing example above keeps a matching
+``cipher`` sub-node on both nodes::
+
+    images {
+        kernel-1 {
+            description = "Linux kernel";
+            data = /incbin/("Image");
+            type = "kernel";
+            arch = "arm64";
+            os = "linux";
+            compression = "none";
+            load = <0x40200000>;
+            entry = <0x40200000>;
+            cipher {
+                algo = "aes256";
+                key-name-hint = "kernel-key";
+                iv-name-hint = "kernel-iv";
+            };
+            hash-1 {
+                algo = "sha256";
+            };
+        };
+        kernel-board-b {
+            description = "Linux kernel at alternate address";
+            image-data = "kernel-1";
+            type = "kernel";
+            arch = "arm64";
+            os = "linux";
+            compression = "none";
+            load = <0x80200000>;
+            entry = <0x80200000>;
+            cipher {
+                algo = "aes256";
+                key-name-hint = "kernel-key";
+                iv-name-hint = "kernel-iv";
+            };
+            hash-1 {
+                algo = "sha256";
+            };
+        };
+    };
+
+Both ``cipher`` sub-nodes use the same ``algo``, ``key-name-hint`` and
+``iv-name-hint``, so the single shared ciphertext decrypts to the same
+plaintext for either node. Relying on the same ``iv-name-hint`` rather than a
+producer-generated random IV is what makes the shared ciphertext
+well-defined.
 
 '/configurations' node
 ----------------------

--- a/source/chapter7-security.rst
+++ b/source/chapter7-security.rst
@@ -81,6 +81,30 @@ Configuration signing prevents this, because the signature binds a specific
 set of images together. A loader that verifies the configuration signature
 knows that this exact combination of images was approved by the signer.
 
+Encryption
+~~~~~~~~~~
+
+Hashing and signing protect *integrity* and *authenticity*: they let a
+consumer detect tampering and confirm that a configuration was approved by a
+trusted signer. They do not provide *confidentiality*: by default the image
+data in a FIT is readable by anyone who has the FIT.
+
+Where an image payload must be kept secret, the image node may carry a
+``cipher`` sub-node so that its data is stored encrypted. The cipher node
+records the algorithm and the hints needed to locate the key and
+initialisation vector, but never the key itself: a FIT is not a confidential
+container, so the key must be provisioned out-of-band into a trusted store
+held by the consumer. See :ref:`cipher-nodes` for the node format.
+
+Encryption is complementary to, and independent of, the integrity scheme:
+
+- The ``cipher`` node is part of the signed node list (see
+  :ref:`hash_contents`), so the algorithm and key/IV hints are authenticated.
+- The image is encrypted before it is hashed, so the image hash covers the
+  ciphertext exactly as it would cover the plaintext of an unencrypted image.
+  A consumer therefore verifies the hash against the stored (encrypted) data
+  and only then decrypts it.
+
 Verification procedure
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -134,7 +158,7 @@ contains:
   (e.g. ``/images/kernel``, ``/images/fdt-1``),
 - the hash sub-nodes of those image nodes
   (e.g. ``/images/kernel/hash-1``, ``/images/fdt-1/hash-1``),
-- any cipher sub-nodes of those image nodes (e.g. ``/images/kernel/cipher-1``), and
+- the cipher sub-node of any encrypted image node (e.g. ``/images/kernel/cipher``), and
 - the ``dm-verity`` sub-node of any ``filesystem``-type image node that carries one
   (e.g. ``/images/rootfs-1/dm-verity``).
 


### PR DESCRIPTION
The /cipher subnode was referenced only once in the spec (the chapter 7 node list for configuration signatures) but never defined. Nothing described its properties, the supported algorithms, where the key material lives, or how a consumer decrypts the image. Its interaction with the recently added image-data sharing mechanism was also unspecified, leaving two conflicting interpretations.

Define the cipher node in chapter 5, documenting:

- the algo (aes128/aes192/aes256, AES-CBC with a 16-byte IV and PKCS#7 padding), key-name-hint, iv-name-hint and iv properties;
- the data-size-unciphered image property added on encryption, and that it is covered by the configuration signature;
- that the key is never stored in the FIT and must be provisioned out-of-band into a trusted store held by the consumer.

Specify that sharing data with an encrypted image shares the ciphertext: the sharing node carries its own cipher subnode with identical algo, key and IV, so AES-CBC determinism yields a single shared ciphertext that decrypts correctly for both nodes. A producer must reject the FIT when the parameters would produce different ciphertext. Add a worked example.

In chapter 7, add an Encryption subsection to the security architecture covering confidentiality versus authentication and the fact that the image is hashed after encryption, and fix the node-list example to use the real node name (cipher, not cipher-1).

Closes: https://github.com/open-source-firmware/flat-image-tree/issues/49