### PR TITLE
add optional RFC 3161 TSA countersignature for signature nodes

### DIFF
--- a/source/chapter5-source-file-format.rst
+++ b/source/chapter5-source-file-format.rst
@@ -548,6 +548,13 @@ padding
     The padding algorithm, it may be pkcs-1.5 or pss,
     if no value is provided we assume pkcs-1.5
 
+tsa-token
+    An optional RFC 3161 [RFC3161]_ ``TimeStampToken``, DER-encoded, that
+    countersigns this node's ``value`` using a Timestamp Authority (TSA)
+    key independent of the image signing key. See :ref:`chapter-security`
+    for the verification procedure. A consumer that does not recognise
+    this property ignores it.
+
 
 .. index:: dm-verity nodes
 
@@ -909,6 +916,13 @@ comment
 padding
     The padding algorithm, it may be pkcs-1.5 or pss,
     if no value is provided we assume pkcs-1.5
+
+tsa-token
+    An optional RFC 3161 [RFC3161]_ ``TimeStampToken``, DER-encoded, that
+    countersigns this node's ``value`` using a Timestamp Authority (TSA)
+    key independent of the image signing key. See :ref:`chapter-security`
+    for the verification procedure. A consumer that does not recognise
+    this property ignores it.
 
 
 .. sectionauthor:: Marian Balakowicz <m8@semihalf.com>

--- a/source/chapter7-security.rst
+++ b/source/chapter7-security.rst
@@ -106,7 +106,56 @@ The bootloader verifies a configuration as follows:
    described in :ref:`verity-usage`, delegating integrity verification to the
    kernel's dm-verity target at mount time.
 
-If any step fails, the configuration must be rejected.
+If any step fails, the configuration must be rejected. Where the signing
+key has an associated validity window and a ``tsa-token`` is present, a
+verifier performs one additional check; see `Temporal proof via RFC 3161
+countersignature`_ below.
+
+.. _tsa-countersignature:
+
+Temporal proof via RFC 3161 countersignature
+---------------------------------------------
+
+Key revocation is normally binary: a verifier either trusts a signing key
+or it does not, and every image signed with a revoked key becomes
+unverifiable, including images produced before the key was revoked --
+whether the reason was compromise, leak, or the signer simply losing
+access to it.
+
+A signature node may carry a ``tsa-token`` property (see
+:ref:`chapter-source-file-format`): a DER-encoded RFC 3161 [RFC3161]_
+``TimeStampToken`` that countersigns ``value``. This token must be
+issued by a Timestamp Authority (TSA), a role distinct from the image
+signer: RFC 3161 section 2.3 requires the key behind it to belong to a
+certificate carrying the ``id-kp-timeStamping`` Extended Key Usage,
+marked critical, and used for no other purpose, so a TSA key can never
+also be a valid image-signing key. It lets a verifier that associates a
+validity window (a ``notBefore``/``notAfter`` pair) with a signing key
+accept images signed inside that window and reject images signed outside
+it, without weakening the revocation itself. A verifier that does not
+recognise ``tsa-token`` ignores it.
+
+When a signing key has an associated validity window and the signature
+node carries a ``tsa-token``, a verifier performs the following checks
+in addition to `Verification procedure`_:
+
+#. Parse ``tsa-token`` as a CMS [RFC5652]_ ``SignedData`` structure and verify that
+   ``TSTInfo.messageImprint`` matches ``value`` hashed with the algorithm
+   named in ``messageImprint.hashAlgorithm``.
+#. ``TSTInfo.policy`` (present in every token per RFC 3161 section
+   2.4.2) carries the TSA policy OID. A verifier holding more than one
+   TSA key in its key store should use this OID to select the right one,
+   then verify the token's CMS signature with it.
+#. Reject if ``TSTInfo.genTime`` falls outside the signing key's validity
+   window.
+
+An operator revokes a key -- whether it was compromised, leaked, or the
+signer simply lost access to it -- by setting the upper bound
+(``notAfter``) of its validity window to the time trust in the key
+ended: images stamped inside the window keep verifying; images produced
+with the key afterwards, whose ``genTime`` falls after ``notAfter``, do
+not. The lower bound (``notBefore``) similarly rejects a token backdated
+to before the key existed.
 
 .. _hash_contents:
 

--- a/source/references.rst
+++ b/source/references.rst
@@ -7,3 +7,7 @@ References
    https://www.devicetree.org/specifications
 .. [VBE] Verified Boot for Embedded (VBE)
    https://docs.u-boot.org/en/latest/develop/vbe.html
+.. [RFC3161] Internet X.509 Public Key Infrastructure Time-Stamp Protocol (TSP)
+   https://www.rfc-editor.org/rfc/rfc3161
+.. [RFC5652] Cryptographic Message Syntax (CMS)
+   https://www.rfc-editor.org/rfc/rfc5652


### PR DESCRIPTION
## Summary

Key revocation in FIT today is binary: a bootloader either trusts a
signing key or it doesn't, and there's no way to tell an image signed
legitimately before a key was stolen from one an attacker produced with
the same key afterward. In practice that breaks factory reset (the
factory image predates the compromise but still gets rejected) and
blocks rollback to a previously-signed kernel or rootfs.

This adds one optional property to the existing `signature-N` node,
`tsa-token`: the DER bytes of an RFC 3161 TimeStampToken, issued by a
dedicated Timestamp Authority (TSA) key, that countersigns the node's
`value`. A verifier that associates a `notBefore`/`notAfter` validity
window with a signing key can use the token's `genTime` to accept images
signed inside that window and reject anything signed outside it, without
changing how `value` itself is checked. A verifier that doesn't know
about `tsa-token` ignores it — the property is additive only, nothing
existing changes.

See `Motivation`_ below for the scenarios this is meant to fix; the
verification algorithm itself is in the chapter7 text this PR adds, so
it isn't repeated here.

## Motivation

Treating revocation as binary produces three field failure modes:

- **Factory reset breaks.** A factory image signed under a
  since-revoked key becomes unbootable — indistinguishable from an
  attacker's image signed with the same stolen key afterwards. The only
  workaround is a bootloader downgrade, which is itself a step backward:
  an older bootloader carries more exposed issues and a larger attack
  surface, which is exactly the state an attacker forcing a factory
  reset would want the device in.
- **Kernel/rootfs rollback is blocked.** Rolling back to the last
  known-good release fails if that release happens to have been signed
  with a key revoked since then. The EU Cyber Resilience Act
  (Regulation 2024/2847) requires devices remain in a functional,
  recoverable state; an update path that can permanently strand a
  device on a defective release sits awkwardly against that.
- **Fleet rollouts stall.** Mid-rollout, some devices have the new
  bootloader (revocation active) and some don't, and the same image
  still has to verify on both generations without maintaining two
  signed copies.

Anti-rollback counters and a certificate `notAfter` checked against
wall-clock time don't cover this: neither gives a verifier proof of
*when* a specific image was signed, independent of the signing key
itself. That's what the RFC 3161 countersignature adds.

## What this changes

- `chapter5-source-file-format.rst` — documents `tsa-token` as an
  optional property on both image-signature and configuration-signature
  nodes.
- `chapter7-security.rst` — adds a "Temporal proof via RFC 3161
  countersignature" section: the problem it solves, why the token must
  come from a dedicated TSA key rather than the image signer (RFC 3161
  §2.3's `id-kp-timeStamping` EKU requirement means the two roles can't
  share a key), and the verification steps a supporting verifier adds on
  top of the existing procedure when a signing key carries a
  `notBefore`/`notAfter` validity window.
- `references.rst` — adds RFC 3161 and RFC 5652 (CMS, which the token's
  `SignedData` structure uses).

## What this deliberately leaves out of scope

The property and its verification semantics are what this specification
can define. How a verifier associates a validity window with a signing
key in the first place — certificate fields, a field next to the key in
its own key store, or something else — is implementation-defined and
left out of the spec text on purpose, since that's key-store format, not
FIT format. One way to do this is extending the existing key-name-hint
lookup with `notBefore`/`notAfter` (roughly what the prototype below
does), but I did not want to normatively bake a specific key-store
layout into this repo, since other consumers with a different key-store
representation should be equally free to implement the check.

Worth noting either way: this only works if the store holds a chain of
keys rather than swapping the current one out. Revoking a key means
giving it a `notAfter` and adding the next key alongside it, not
replacing it — an old image still needs its original signing key, window
and all, to be found.

## Reference implementation — please read before assuming this is proven

An experimental, non-normative prototype of this mechanism exists for
barebox: https://github.com/anischali/barebox/tree/CA/tsp. It parses and
verifies RFC 3161 tokens, associates a validity window with a signing
key, and gates enforcement behind a build-time option. As of this
writing it has not been reviewed or merged upstream, and some of its
pieces are still scaffolding rather than a finished feature. It's
referenced here only as a worked example of the mechanism, not as a
conformance requirement of this specification — which is also why I kept
it out of the spec text itself and put the caveats here instead.

To be precise about what does and doesn't exist behind this text, since
a spec change is easy to over-claim:

- The prototype parses and verifies RFC 3161 tokens, looks up a TSA key
  by policy OID, adds a validity window (`not_before`/`not_after`) to
  `struct public_key`, and wires `tsa-token` checking into
  `image-fit.c` behind a new Kconfig option.
- It is a prototype, not a finished or reviewed feature. Concretely:
  the Kconfig option (`BOOTM_FORCE_SIGNED_IMAGES_WITH_TSA`) currently
  requires a `tsa-token` globally on every signed image rather than only
  on keys that carry an expiry (the per-key
  `not_before`/`not_after` window itself is enforced correctly once a
  token is present — it's the "is a token required at all" decision that
  isn't yet per-key); a `BOOTM_VERIFY_TSA_TOKEN` enum value was added to
  `bootm.c` that no code path sets yet; and none of it has had review,
  testing against real TSA responses beyond my own, or upstream barebox
  feedback.
- On the signing side, `scripts/tsa-stamp.py` sends a signature node's
  `value` to an RFC 3161 TSA (a URL, or a local freetsa-style server
  picked by name) and writes the returned token back as that node's
  `tsa-token`. It's a standalone script, not a `mkimage` flag.
- I have not implemented or tested any of this against U-Boot / mkimage,
  which is this spec's primary reference implementation.

What building the prototype actually took, roughly in order:

- Importing the ASN.1 BER decoder and OID registry Linux's own crypto
  code uses, rather than writing a new parser, to decode the token's CMS
  `SignedData`/`TSTInfo` structure.
- Writing the RFC 3161/CMS parsing and verification itself: message
  imprint check, signed-attributes digest check, SET-tag substitution
  per RFC 5652 §5.4, and the CMS signature check against a TSA key
  looked up by policy OID.
- Adding the validity window: `not_before`/`not_after` on
  `struct public_key`, sourced from `rsa,not-before`/`rsa,not-after`
  devicetree properties, with `keytoc` extracting the same fields from a
  certificate at build time.
- A handful of smaller fixups needed to get there: relaxing `keytoc`'s
  key-name-hint grammar to accept dotted-decimal OIDs, DER-encoded ECDSA
  signature support, secp384r1 support, and a couple of build/gitignore
  fixes.
- Wiring the verification side into `image-fit.c` and `bootm.c` behind
  the new Kconfig option — the least finished part, per the caveats
  above — and the signing side into `tsa-stamp.py`, so there's a way to
  actually produce a stamped FIT to test the verification code against.

Comments welcome — happy to adjust the wording, move content between
chapters, or split this into smaller patches if that's preferred.

Signed-off-by: Chali Anis <chalianis1@gmail.com>
Co-developed-by: Claude <noreply@anthropic.com>